### PR TITLE
feat: Add /v1/agent-info pass-through for UI settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ helm upgrade --install my-gateway chart/ \
 
 ## Scaffolding
 
-This repository is a template used by [fips-agents-cli](https://github.com/rdwj/fips-agents-cli). To create a new gateway project:
+This repository is a template used by [fips-agents-cli](https://github.com/fips-agents/fips-agents-cli). To create a new gateway project:
 
 ```bash
 fips-agents create gateway my-gateway-name

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -39,6 +40,17 @@ func main() {
 	mux.Handle("/.well-known/agent.json", &handler.WellKnownHandler{
 		AgentName:    cfg.AgentName,
 		AgentVersion: cfg.AgentVersion,
+	})
+	mux.HandleFunc("GET /v1/agent-info", func(w http.ResponseWriter, r *http.Request) {
+		resp, err := client.Get(cfg.BackendURL + "/v1/agent-info")
+		if err != nil {
+			http.Error(w, "backend unreachable", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
 	})
 
 	var handler http.Handler = mux

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/config"
-	"github.com/redhat-ai-americas/gateway-template/internal/handler"
-	"github.com/redhat-ai-americas/gateway-template/internal/middleware"
+	"github.com/fips-agents/gateway-template/internal/config"
+	"github.com/fips-agents/gateway-template/internal/handler"
+	"github.com/fips-agents/gateway-template/internal/middleware"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/redhat-ai-americas/gateway-template
+module github.com/fips-agents/gateway-template
 
 go 1.22

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/proxy"
+	"github.com/fips-agents/gateway-template/internal/proxy"
 )
 
 // ChatHandler proxies OpenAI-compatible /v1/chat/completions requests to a

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/handler"
+	"github.com/fips-agents/gateway-template/internal/handler"
 )
 
 // sampleCompletion is a minimal OpenAI-compatible chat completion response.

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/handler"
+	"github.com/fips-agents/gateway-template/internal/handler"
 )
 
 func TestHealthHandler(t *testing.T) {

--- a/internal/handler/wellknown_test.go
+++ b/internal/handler/wellknown_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/handler"
+	"github.com/fips-agents/gateway-template/internal/handler"
 )
 
 func TestWellKnownHandler(t *testing.T) {

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/middleware"
+	"github.com/fips-agents/gateway-template/internal/middleware"
 )
 
 // restoreDefaultLogger resets slog to a safe default that writes to stderr.

--- a/internal/proxy/sse_test.go
+++ b/internal/proxy/sse_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redhat-ai-americas/gateway-template/internal/proxy"
+	"github.com/fips-agents/gateway-template/internal/proxy"
 )
 
 // fakeResponse builds an *http.Response whose Body reads from the given string.


### PR DESCRIPTION
## Summary

- Adds `GET /v1/agent-info` handler to the gateway mux that proxies the request to the configured backend URL and streams the response back verbatim
- Follows the same pass-through pattern used in other gateway deployments (calculus-gateway)
- Adds `"io"` to the import block (needed for `io.Copy`)

## Test plan

- [ ] Deploy gateway with a backend that serves `GET /v1/agent-info` and confirm the response is forwarded correctly with the right status code and `Content-Type: application/json`
- [ ] Confirm a 502 is returned when the backend is unreachable