### PR TITLE
chore: Add CODEOWNERS for branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners - all PRs require approval from @rdwj
+*       @rdwj


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` requiring @rdwj approval on all PRs
- Companion to the branch protection rules now active on `main`

## Test plan

- [ ] Verify CODEOWNERS renders correctly on GitHub
- [ ] Confirm subsequent PRs require code owner review