### PR TITLE
feat: Route /v1/feedback endpoints to backend agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ This is a thin reverse proxy -- no business logic, no external dependencies. All
 ```
 Client --> Gateway (:8080) --> Backend Agent
              |
-             +-- /v1/chat/completions  (POST, sync + SSE streaming)
+             +-- /v1/chat/completions  (POST, sync + SSE streaming, propagates X-Trace-Id)
              +-- /v1/feedback          (POST/GET, pass-through, forwards auth headers)
+             +-- /v1/feedback/{id}     (PATCH, in-place edit of an existing record)
              +-- /v1/feedback/stats    (GET, pass-through)
              +-- /v1/agent-info        (GET, pass-through to backend)
              +-- /healthz              (GET, liveness)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ This is a thin reverse proxy -- no business logic, no external dependencies. All
 Client --> Gateway (:8080) --> Backend Agent
              |
              +-- /v1/chat/completions  (POST, sync + SSE streaming)
+             +-- /v1/feedback          (POST/GET, pass-through, forwards auth headers)
+             +-- /v1/feedback/stats    (GET, pass-through)
              +-- /v1/agent-info        (GET, pass-through to backend)
              +-- /healthz              (GET, liveness)
              +-- /readyz               (GET, checks backend)

--- a/README.md
+++ b/README.md
@@ -31,13 +31,16 @@ curl http://localhost:8080/healthz
 |---|---|---|
 | `/v1/chat/completions` | POST | OpenAI-compatible chat completions (sync + streaming) |
 | `/v1/feedback` | POST, GET | User feedback submit/list (pass-through to backend) |
+| `/v1/feedback/{feedback_id}` | PATCH | In-place edit of an existing feedback record |
 | `/v1/feedback/stats` | GET | Aggregated feedback stats (pass-through to backend) |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe (checks backend connectivity) |
 | `/v1/agent-info` | GET | Pass-through to backend agent info (UI settings) |
 | `/.well-known/agent.json` | GET | Agent discovery card |
 
-The feedback endpoints forward `Authorization`, `X-User-ID`, and `X-Forwarded-User` headers so the backend can attribute feedback to the calling user. Other headers are dropped.
+The feedback endpoints forward `Authorization`, `X-User-ID`, and `X-Forwarded-User` headers so the backend can attribute feedback to the calling user. Other request headers are dropped.
+
+On the response side the gateway propagates a small allowlist back to the client — currently just `X-Trace-Id`, which the agent backend sets on every chat completion response so the UI can submit feedback against a known trace.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ curl http://localhost:8080/healthz
 | Path | Method | Description |
 |---|---|---|
 | `/v1/chat/completions` | POST | OpenAI-compatible chat completions (sync + streaming) |
+| `/v1/feedback` | POST, GET | User feedback submit/list (pass-through to backend) |
+| `/v1/feedback/stats` | GET | Aggregated feedback stats (pass-through to backend) |
 | `/healthz` | GET | Liveness probe |
 | `/readyz` | GET | Readiness probe (checks backend connectivity) |
 | `/v1/agent-info` | GET | Pass-through to backend agent info (UI settings) |
 | `/.well-known/agent.json` | GET | Agent discovery card |
+
+The feedback endpoints forward `Authorization`, `X-User-ID`, and `X-Forwarded-User` headers so the backend can attribute feedback to the calling user. Other headers are dropped.
 
 ## Deployment
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,11 +32,14 @@ func main() {
 		BackendURL: cfg.BackendURL,
 		Client:     client,
 	})
-	mux.Handle("/v1/feedback", &handler.FeedbackHandler{
+	feedbackHandler := &handler.FeedbackHandler{BackendURL: cfg.BackendURL, Client: client}
+	mux.Handle("POST /v1/feedback", feedbackHandler)
+	mux.Handle("GET /v1/feedback", feedbackHandler)
+	mux.Handle("GET /v1/feedback/stats", &handler.FeedbackStatsHandler{
 		BackendURL: cfg.BackendURL,
 		Client:     client,
 	})
-	mux.Handle("/v1/feedback/stats", &handler.FeedbackStatsHandler{
+	mux.Handle("PATCH /v1/feedback/{feedback_id}", &handler.FeedbackByIdHandler{
 		BackendURL: cfg.BackendURL,
 		Client:     client,
 	})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,14 @@ func main() {
 		BackendURL: cfg.BackendURL,
 		Client:     client,
 	})
+	mux.Handle("/v1/feedback", &handler.FeedbackHandler{
+		BackendURL: cfg.BackendURL,
+		Client:     client,
+	})
+	mux.Handle("/v1/feedback/stats", &handler.FeedbackStatsHandler{
+		BackendURL: cfg.BackendURL,
+		Client:     client,
+	})
 	mux.Handle("/healthz", &handler.HealthHandler{})
 	mux.Handle("/readyz", &handler.ReadyHandler{
 		BackendURL: cfg.BackendURL,

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -50,6 +50,22 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// passThroughHeaders are response headers copied from the backend to the
+// client. The list is deliberately narrow — keep the gateway thin and
+// avoid leaking internal headers.
+var passThroughHeaders = []string{
+	"X-Trace-Id",
+}
+
+// copyPassThroughHeaders copies the allowlisted headers from src to dst.
+func copyPassThroughHeaders(dst http.Header, src http.Header) {
+	for _, name := range passThroughHeaders {
+		if v := src.Get(name); v != "" {
+			dst.Set(name, v)
+		}
+	}
+}
+
 // proxySync forwards the request and returns the full backend response.
 func (h *ChatHandler) proxySync(w http.ResponseWriter, body []byte) {
 	resp, err := h.doBackendRequest(body)
@@ -61,6 +77,7 @@ func (h *ChatHandler) proxySync(w http.ResponseWriter, body []byte) {
 	defer resp.Body.Close()
 
 	w.Header().Set("Content-Type", "application/json")
+	copyPassThroughHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		slog.Warn("error copying backend response", "error", err)
@@ -80,6 +97,7 @@ func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, body []byte) {
 
 	if resp.StatusCode != http.StatusOK {
 		w.Header().Set("Content-Type", "application/json")
+		copyPassThroughHeaders(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
 		io.Copy(w, resp.Body)
 		return
@@ -89,6 +107,7 @@ func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, body []byte) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+	copyPassThroughHeaders(w.Header(), resp.Header)
 
 	proxy.RelaySSE(resp, w)
 }

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -231,6 +231,32 @@ func TestChatHandler_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestChatHandler_PropagatesXTraceIdHeader(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Trace-Id", "trace_abcdef0123456789")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"chatcmpl-x"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.ChatHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	reqBody := `{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Trace-Id"); got != "trace_abcdef0123456789" {
+		t.Errorf("X-Trace-Id not propagated; got %q", got)
+	}
+}
+
 func TestChatHandler_StreamingBackendError(t *testing.T) {
 	// Backend returns 500 on a streaming request -- gateway should forward the
 	// error status rather than switching to SSE mode.

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -104,6 +104,7 @@ func proxyPassthrough(w http.ResponseWriter, r *http.Request, client *http.Clien
 	} else {
 		w.Header().Set("Content-Type", "application/json")
 	}
+	copyPassThroughHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		slog.Warn("error copying backend response", "error", err)

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+// authHeaders are the request headers forwarded to the backend so it can
+// attribute feedback to the calling user. Other headers are dropped.
+var authHeaders = []string{
+	"Authorization",
+	"X-User-ID",
+	"X-Forwarded-User",
+}
+
+// FeedbackHandler proxies user feedback API requests to the backend agent
+// service. It supports POST and GET on /v1/feedback. The companion
+// FeedbackStatsHandler covers /v1/feedback/stats.
+//
+// The gateway does not interpret or store feedback payloads; it forwards
+// the body and query string verbatim, with selected authentication headers
+// preserved so the backend can attribute the record to the correct user.
+type FeedbackHandler struct {
+	BackendURL string
+	Client     *http.Client
+}
+
+// ServeHTTP dispatches POST and GET to the backend, returning 405 for any
+// other method.
+func (h *FeedbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodGet:
+		proxyPassthrough(w, r, h.Client, h.BackendURL+"/v1/feedback")
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+// FeedbackStatsHandler proxies GET /v1/feedback/stats to the backend.
+type FeedbackStatsHandler struct {
+	BackendURL string
+	Client     *http.Client
+}
+
+func (h *FeedbackStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	proxyPassthrough(w, r, h.Client, h.BackendURL+"/v1/feedback/stats")
+}
+
+// proxyPassthrough forwards a request to backendURL, preserving method,
+// query string, body, Content-Type, and selected auth headers. The backend
+// response (status, Content-Type, body) is copied to w.
+func proxyPassthrough(w http.ResponseWriter, r *http.Request, client *http.Client, backendURL string) {
+	var body io.Reader
+	if r.Method == http.MethodPost {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			slog.Error("failed to read request body", "error", err)
+			http.Error(w, `{"error":"failed to read request body"}`, http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+		body = bytes.NewReader(raw)
+	}
+
+	url := backendURL
+	if r.URL.RawQuery != "" {
+		url = url + "?" + r.URL.RawQuery
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, url, body)
+	if err != nil {
+		slog.Error("failed to build backend request", "error", err)
+		http.Error(w, `{"error":"failed to build backend request"}`, http.StatusInternalServerError)
+		return
+	}
+
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	} else if r.Method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for _, name := range authHeaders {
+		if v := r.Header.Get(name); v != "" {
+			req.Header.Set(name, v)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("backend request failed", "error", err, "url", backendURL)
+		http.Error(w, `{"error":"backend request failed"}`, http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		slog.Warn("error copying backend response", "error", err)
+	}
+}

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -38,6 +38,28 @@ func (h *FeedbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// FeedbackByIdHandler proxies PATCH /v1/feedback/{feedback_id} to the
+// backend.  Registered separately from FeedbackHandler because Go's
+// http.ServeMux treats `/v1/feedback` and `/v1/feedback/<id>` as distinct
+// patterns.  Wired in main.go via the Go 1.22 pattern syntax.
+type FeedbackByIdHandler struct {
+	BackendURL string
+	Client     *http.Client
+}
+
+func (h *FeedbackByIdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.PathValue("feedback_id")
+	if id == "" {
+		http.Error(w, `{"error":"feedback_id required"}`, http.StatusBadRequest)
+		return
+	}
+	proxyPassthrough(w, r, h.Client, h.BackendURL+"/v1/feedback/"+id)
+}
+
 // FeedbackStatsHandler proxies GET /v1/feedback/stats to the backend.
 type FeedbackStatsHandler struct {
 	BackendURL string
@@ -57,7 +79,7 @@ func (h *FeedbackStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 // response (status, Content-Type, body) is copied to w.
 func proxyPassthrough(w http.ResponseWriter, r *http.Request, client *http.Client, backendURL string) {
 	var body io.Reader
-	if r.Method == http.MethodPost {
+	if r.Method == http.MethodPost || r.Method == http.MethodPatch || r.Method == http.MethodPut {
 		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			slog.Error("failed to read request body", "error", err)
@@ -82,7 +104,7 @@ func proxyPassthrough(w http.ResponseWriter, r *http.Request, client *http.Clien
 
 	if ct := r.Header.Get("Content-Type"); ct != "" {
 		req.Header.Set("Content-Type", ct)
-	} else if r.Method == http.MethodPost {
+	} else if r.Method == http.MethodPost || r.Method == http.MethodPatch || r.Method == http.MethodPut {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	for _, name := range authHeaders {

--- a/internal/handler/feedback_test.go
+++ b/internal/handler/feedback_test.go
@@ -169,6 +169,60 @@ func TestFeedbackHandler_BackendError(t *testing.T) {
 	}
 }
 
+func TestFeedbackByIdHandler_PatchProxy(t *testing.T) {
+	var capturedPath, capturedMethod, capturedBody string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"feedback_id":"fb_x","rating":-1}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.FeedbackByIdHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/feedback/fb_x",
+		strings.NewReader(`{"rating":-1,"comment":"updated"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("feedback_id", "fb_x")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH proxy: want 200, got %d", rec.Code)
+	}
+	if capturedMethod != http.MethodPatch {
+		t.Errorf("backend received %s, want PATCH", capturedMethod)
+	}
+	if capturedPath != "/v1/feedback/fb_x" {
+		t.Errorf("backend path = %q, want /v1/feedback/fb_x", capturedPath)
+	}
+	if capturedBody != `{"rating":-1,"comment":"updated"}` {
+		t.Errorf("backend body = %q, want body forwarded verbatim", capturedBody)
+	}
+}
+
+func TestFeedbackByIdHandler_RejectsNonPatch(t *testing.T) {
+	h := &handler.FeedbackByIdHandler{
+		BackendURL: "http://127.0.0.1:0",
+		Client:     &http.Client{},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback/fb_x", nil)
+	req.SetPathValue("feedback_id", "fb_x")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", rec.Code)
+	}
+}
+
 func TestFeedbackStatsHandler_GetProxy(t *testing.T) {
 	var capturedQuery string
 

--- a/internal/handler/feedback_test.go
+++ b/internal/handler/feedback_test.go
@@ -1,0 +1,222 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fips-agents/gateway-template/internal/handler"
+)
+
+func TestFeedbackHandler_PostProxy(t *testing.T) {
+	var capturedBody []byte
+	var capturedAuth string
+	var capturedUser string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("backend: want POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feedback" {
+			t.Errorf("backend: want path /v1/feedback, got %s", r.URL.Path)
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		capturedAuth = r.Header.Get("Authorization")
+		capturedUser = r.Header.Get("X-User-ID")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"feedback_id":"fb_abc123"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.FeedbackHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	reqBody := `{"trace_id":"tr_1","rating":1,"comment":"great"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("X-User-ID", "user-42")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post proxy: want status %d, got %d (body: %s)", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+	if string(capturedBody) != reqBody {
+		t.Errorf("post proxy: want body %q forwarded, got %q", reqBody, string(capturedBody))
+	}
+	if capturedAuth != "Bearer secret-token" {
+		t.Errorf("post proxy: Authorization header not forwarded, got %q", capturedAuth)
+	}
+	if capturedUser != "user-42" {
+		t.Errorf("post proxy: X-User-ID header not forwarded, got %q", capturedUser)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("post proxy: response is not valid JSON: %v", err)
+	}
+	if got["feedback_id"] != "fb_abc123" {
+		t.Errorf("post proxy: want feedback_id=fb_abc123, got %v", got["feedback_id"])
+	}
+}
+
+func TestFeedbackHandler_GetProxyWithQuery(t *testing.T) {
+	var capturedQuery string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("backend: want GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feedback" {
+			t.Errorf("backend: want path /v1/feedback, got %s", r.URL.Path)
+		}
+		capturedQuery = r.URL.RawQuery
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"feedback_id":"fb_1","rating":1}]`))
+	}))
+	defer backend.Close()
+
+	h := &handler.FeedbackHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/feedback?trace_id=tr_1&limit=10", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get proxy: want status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if capturedQuery != "trace_id=tr_1&limit=10" {
+		t.Errorf("get proxy: query string not forwarded, got %q", capturedQuery)
+	}
+}
+
+func TestFeedbackHandler_MethodNotAllowed(t *testing.T) {
+	h := &handler.FeedbackHandler{
+		BackendURL: "http://localhost:0",
+		Client:     &http.Client{},
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/feedback", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("method not allowed: want status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+}
+
+func TestFeedbackHandler_BackendUnreachable(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := backend.URL
+	backend.Close()
+
+	h := &handler.FeedbackHandler{
+		BackendURL: closedURL,
+		Client:     &http.Client{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(`{"trace_id":"x","rating":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("backend unreachable: want status %d, got %d", http.StatusBadGateway, rec.Code)
+	}
+}
+
+func TestFeedbackHandler_BackendError(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"trace_id is required"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.FeedbackHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("backend error: want status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "trace_id is required") {
+		t.Errorf("backend error: expected error message in response, got %q", rec.Body.String())
+	}
+}
+
+func TestFeedbackStatsHandler_GetProxy(t *testing.T) {
+	var capturedQuery string
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("backend: want GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feedback/stats" {
+			t.Errorf("backend: want path /v1/feedback/stats, got %s", r.URL.Path)
+		}
+		capturedQuery = r.URL.RawQuery
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"window_start":"2026-04-01T00:00:00Z","thumbs_up":3,"thumbs_down":1,"total":4}]`))
+	}))
+	defer backend.Close()
+
+	h := &handler.FeedbackStatsHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/feedback/stats?window=day&agent_type=chat", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stats proxy: want status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if capturedQuery != "window=day&agent_type=chat" {
+		t.Errorf("stats proxy: query string not forwarded, got %q", capturedQuery)
+	}
+}
+
+func TestFeedbackStatsHandler_MethodNotAllowed(t *testing.T) {
+	h := &handler.FeedbackStatsHandler{
+		BackendURL: "http://localhost:0",
+		Client:     &http.Client{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/feedback/stats", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("method not allowed: want status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+}

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@ This is a template repository. The sentinel string `gateway-template` is replace
 ## Handlers
 
 - [Chat completions](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/chat.go): POST /v1/chat/completions — sync and SSE streaming proxy
+- [Feedback](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/feedback.go): POST/GET /v1/feedback and GET /v1/feedback/stats — pass-through with auth header forwarding
 - [Health](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/health.go): GET /healthz and /readyz endpoints
 - [Agent card](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/wellknown.go): GET /.well-known/agent.json
 


### PR DESCRIPTION
## Summary

- Adds `POST /v1/feedback`, `GET /v1/feedback`, and `GET /v1/feedback/stats` reverse-proxy routes for the user feedback API exposed by the backend in `fipsagents` v0.12.x.
- Forwards body, query string, and a narrow allowlist of auth headers (`Authorization`, `X-User-ID`, `X-Forwarded-User`) so the backend can attribute feedback. No gateway-side storage or interpretation.
- Updates README, llms.txt, and CLAUDE.md endpoint tables.

Closes #10. Companion issues live on `agent-template`, `ui-template`, `fips-agents-cli`, and `examples`.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` — adds 7 cases covering POST forward, GET query forward, header forwarding, method-not-allowed, backend error, and backend unreachable
- [ ] End-to-end check against a running agent backend with feedback enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)