### PR TITLE
feat: Canonical X-Auth-* headers (v1: anonymous + proxy modes) — closes #21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Key packages:
 - `internal/config/` -- environment variable parsing
 - `internal/handler/` -- HTTP handlers for each route
 - `internal/middleware/` -- request logging (structured, skips health probes)
+- `internal/auth/` -- inbound auth strategies (`anonymous`, `proxy`) + middleware that strips spoofed `X-Auth-*` headers and projects canonical identity onto the request
 - `internal/proxy/` -- SSE relay logic
 
 ## Configuration
@@ -56,6 +57,13 @@ Key packages:
 | `AGENT_NAME` | No | `gateway-template` | Name in agent card |
 | `AGENT_VERSION` | No | `0.1.0` | Version in agent card |
 | `LOG_REQUESTS` | No | `false` | Enable structured request logging |
+| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous` or `proxy` |
+| `GATEWAY_AUTH_PROXY_USER_HEADER` | No | `X-Forwarded-User` | (`proxy` mode) upstream-validated username header |
+| `GATEWAY_AUTH_PROXY_EMAIL_HEADER` | No | `X-Forwarded-Email` | (`proxy` mode) upstream-validated email header |
+
+## Auth contract
+
+The gateway emits canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers to the backend on every `/v1/*` request. Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's JWT claim shape so the contract survives a future swap to in-process JWKS validation. `proxy` mode fails closed with 503 when the upstream user header is missing. `jwt` mode (in-process JWKS) is deferred to v2.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ curl http://localhost:8080/healthz
 | `AGENT_NAME` | No | `gateway-template` | Agent name in `/.well-known/agent.json` |
 | `AGENT_VERSION` | No | `0.1.0` | Agent version in `/.well-known/agent.json` |
 | `LOG_REQUESTS` | No | `false` | Enable structured request logging (skips health probes) |
+| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous` or `proxy` |
+| `GATEWAY_AUTH_PROXY_USER_HEADER` | No | `X-Forwarded-User` | (`proxy` mode) header carrying the upstream-validated username |
+| `GATEWAY_AUTH_PROXY_EMAIL_HEADER` | No | `X-Forwarded-Email` | (`proxy` mode) header carrying the upstream-validated email; empty disables email projection |
+
+## Authentication
+
+The gateway issues a canonical set of trusted headers to the backend agent on every request:
+
+| Header | Description |
+|---|---|
+| `X-Auth-Subject` | Stable identifier (`anonymous` or the upstream-validated username) |
+| `X-Auth-User` | Human-readable username (may be empty in `anonymous` mode) |
+| `X-Auth-Email` | Email address (may be empty) |
+| `X-Auth-Mode` | `anonymous` or `proxy` |
+
+Inbound copies of these headers are stripped before the strategy runs, so a client cannot spoof identity by setting them directly. The header names match Kagenti's JWT claim shape so the contract survives a future swap to in-process JWKS validation without breaking the agent.
+
+**Modes** (`GATEWAY_AUTH_MODE`):
+
+- `anonymous` *(default)* — no validation. `X-Auth-Subject` is set to `anonymous`. Use for local dev, smoke tests, or any deployment that does not need user attribution.
+- `proxy` — trust an upstream OAuth proxy (e.g. OpenShift `oauth-proxy` sidecar) or service-mesh `outputClaimToHeaders` filter. The gateway reads `X-Forwarded-User` / `X-Forwarded-Email` (header names configurable) and projects them onto the canonical headers. **The gateway pod must be unreachable except via that proxy** — otherwise a client can spoof the upstream headers. If the user header is missing, the gateway returns 503 (fail closed). In-process JWKS validation is deferred to v2.
 
 ## Endpoints
 
@@ -38,7 +59,7 @@ curl http://localhost:8080/healthz
 | `/v1/agent-info` | GET | Pass-through to backend agent info (UI settings) |
 | `/.well-known/agent.json` | GET | Agent discovery card |
 
-The feedback endpoints forward `Authorization`, `X-User-ID`, and `X-Forwarded-User` headers so the backend can attribute feedback to the calling user. Other request headers are dropped.
+All `/v1/*` endpoints forward the canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers (see Authentication above) so the backend can attribute requests to the resolved identity. Other request headers are dropped.
 
 On the response side the gateway propagates a small allowlist back to the client — currently just `X-Trace-Id`, which the agent backend sets on every chat completion response so the UI can submit feedback against a known trace.
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 description: Go HTTP gateway for AI agents

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -8,3 +8,6 @@ data:
   {{- range $key, $val := .Values.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+  GATEWAY_AUTH_MODE: {{ .Values.auth.mode | quote }}
+  GATEWAY_AUTH_PROXY_USER_HEADER: {{ .Values.auth.proxy.userHeader | quote }}
+  GATEWAY_AUTH_PROXY_EMAIL_HEADER: {{ .Values.auth.proxy.emailHeader | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,6 +16,21 @@ resources:
 config:
   BACKEND_URL: http://my-agent:8080
 
+# Inbound auth strategy. See internal/auth and gateway-template#21.
+#   anonymous (default) — no validation, X-Auth-Subject is "anonymous".
+#                         Use for local dev, smoke tests, or any deployment
+#                         that does not need user attribution.
+#   proxy               — trust an upstream OAuth proxy (or service-mesh
+#                         outputClaimToHeaders) to project identity into
+#                         X-Forwarded-User / X-Forwarded-Email. The
+#                         gateway pod MUST be unreachable except via that
+#                         proxy, otherwise headers can be spoofed.
+auth:
+  mode: anonymous
+  proxy:
+    userHeader: X-Forwarded-User
+    emailHeader: X-Forwarded-Email
+
 service:
   port: 8080
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fips-agents/gateway-template/internal/auth"
 	"github.com/fips-agents/gateway-template/internal/config"
 	"github.com/fips-agents/gateway-template/internal/handler"
 	"github.com/fips-agents/gateway-template/internal/middleware"
@@ -22,6 +23,12 @@ func main() {
 	cfg, err := config.Load()
 	if err != nil {
 		slog.Error("configuration error", "error", err)
+		os.Exit(1)
+	}
+
+	authenticator, err := auth.New(cfg.AuthMode, cfg.AuthProxyUserHeader, cfg.AuthProxyEmailHeader)
+	if err != nil {
+		slog.Error("auth configuration error", "error", err)
 		os.Exit(1)
 	}
 
@@ -64,14 +71,17 @@ func main() {
 		io.Copy(w, resp.Body)
 	})
 
-	var handler http.Handler = mux
+	// Auth runs first so logs (and any later middleware) see the resolved
+	// canonical X-Auth-* headers and never see spoofed inbound copies.
+	var rootHandler http.Handler = mux
 	if cfg.LogRequests {
-		handler = middleware.LogRequests(handler)
+		rootHandler = middleware.LogRequests(rootHandler)
 	}
+	rootHandler = auth.Middleware(authenticator)(rootHandler)
 
 	srv := &http.Server{
 		Addr:              net.JoinHostPort("", cfg.Port),
-		Handler:           handler,
+		Handler:           rootHandler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -85,6 +95,7 @@ func main() {
 			"backend", cfg.BackendURL,
 			"agent", cfg.AgentName,
 			"version", cfg.AgentVersion,
+			"auth_mode", cfg.AuthMode,
 		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,132 @@
+// Package auth resolves the identity of inbound requests and projects it
+// onto a canonical set of trusted headers that the gateway forwards to the
+// backend agent.
+//
+// Header contract emitted to the backend:
+//
+//	X-Auth-Subject  — stable identifier (JWT sub, OpenShift uid, or "anonymous")
+//	X-Auth-User     — human-readable username, may be empty
+//	X-Auth-Email    — email address, may be empty
+//	X-Auth-Mode     — "anonymous" | "proxy"
+//
+// The header names match Kagenti's JWT claim shape so the contract survives
+// a future swap to AuthBridge / in-process JWKS without breaking the agent.
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Mode names. Keep in sync with config.Config.AuthMode validation.
+const (
+	ModeAnonymous = "anonymous"
+	ModeProxy     = "proxy"
+)
+
+// Canonical header names emitted to the backend.
+const (
+	HeaderSubject = "X-Auth-Subject"
+	HeaderUser    = "X-Auth-User"
+	HeaderEmail   = "X-Auth-Email"
+	HeaderMode    = "X-Auth-Mode"
+)
+
+// CanonicalHeaders lists every header the gateway issues. Inbound copies
+// of these are stripped before the strategy runs to prevent client spoofing.
+var CanonicalHeaders = []string{
+	HeaderSubject,
+	HeaderUser,
+	HeaderEmail,
+	HeaderMode,
+}
+
+// Identity is the resolved caller identity.
+type Identity struct {
+	Subject string
+	User    string
+	Email   string
+	Mode    string
+}
+
+// ErrMissingProxyHeaders signals that proxy mode was configured but the
+// upstream did not project the expected user header. Surfaced as 503 so a
+// misconfigured deployment fails closed instead of silently degrading to
+// anonymous.
+var ErrMissingProxyHeaders = errors.New("auth: proxy mode but upstream identity headers are missing")
+
+// Authenticator resolves an Identity from an inbound request. Implementations
+// must not mutate r.
+type Authenticator interface {
+	Authenticate(r *http.Request) (Identity, error)
+}
+
+// New returns the authenticator for the given mode. userHeader and
+// emailHeader are only consulted in proxy mode.
+func New(mode, userHeader, emailHeader string) (Authenticator, error) {
+	switch mode {
+	case ModeAnonymous, "":
+		return &AnonymousAuth{}, nil
+	case ModeProxy:
+		if userHeader == "" {
+			return nil, fmt.Errorf("auth: proxy mode requires a non-empty user header name")
+		}
+		return &ProxyAuth{
+			UserHeader:  userHeader,
+			EmailHeader: emailHeader,
+		}, nil
+	default:
+		return nil, fmt.Errorf("auth: unknown mode %q (want %q or %q)", mode, ModeAnonymous, ModeProxy)
+	}
+}
+
+// AnonymousAuth always returns the anonymous identity. Used for local dev,
+// the smoke script, and any deployment where identity is not required.
+type AnonymousAuth struct{}
+
+// Authenticate returns the canonical anonymous identity.
+func (a *AnonymousAuth) Authenticate(r *http.Request) (Identity, error) {
+	return Identity{
+		Subject: "anonymous",
+		User:    "",
+		Email:   "",
+		Mode:    ModeAnonymous,
+	}, nil
+}
+
+// ProxyAuth trusts an upstream OAuth proxy (or service-mesh authn filter)
+// to project the authenticated user into request headers. The gateway pod
+// must be unreachable except via that proxy, otherwise a client can spoof
+// the headers.
+type ProxyAuth struct {
+	// UserHeader is the request header carrying the username, e.g.
+	// "X-Forwarded-User" (oauth-proxy default).
+	UserHeader string
+	// EmailHeader is the request header carrying the email address, e.g.
+	// "X-Forwarded-Email". Optional — when empty or unset the resolved
+	// identity has no email.
+	EmailHeader string
+}
+
+// Authenticate reads the configured upstream headers and projects them
+// onto the canonical Identity. Returns ErrMissingProxyHeaders when the
+// user header is absent so the caller can fail closed.
+func (p *ProxyAuth) Authenticate(r *http.Request) (Identity, error) {
+	user := r.Header.Get(p.UserHeader)
+	if user == "" {
+		return Identity{}, ErrMissingProxyHeaders
+	}
+
+	email := ""
+	if p.EmailHeader != "" {
+		email = r.Header.Get(p.EmailHeader)
+	}
+
+	return Identity{
+		Subject: user,
+		User:    user,
+		Email:   email,
+		Mode:    ModeProxy,
+	}, nil
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,154 @@
+package auth_test
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fips-agents/gateway-template/internal/auth"
+)
+
+func TestNew_DefaultsToAnonymous(t *testing.T) {
+	a, err := auth.New("", "", "")
+	if err != nil {
+		t.Fatalf("New(\"\"): unexpected error: %v", err)
+	}
+	if _, ok := a.(*auth.AnonymousAuth); !ok {
+		t.Fatalf("New(\"\"): want *AnonymousAuth, got %T", a)
+	}
+}
+
+func TestNew_AnonymousMode(t *testing.T) {
+	a, err := auth.New(auth.ModeAnonymous, "", "")
+	if err != nil {
+		t.Fatalf("New(anonymous): unexpected error: %v", err)
+	}
+	if _, ok := a.(*auth.AnonymousAuth); !ok {
+		t.Fatalf("New(anonymous): want *AnonymousAuth, got %T", a)
+	}
+}
+
+func TestNew_ProxyMode(t *testing.T) {
+	a, err := auth.New(auth.ModeProxy, "X-Forwarded-User", "X-Forwarded-Email")
+	if err != nil {
+		t.Fatalf("New(proxy): unexpected error: %v", err)
+	}
+	pa, ok := a.(*auth.ProxyAuth)
+	if !ok {
+		t.Fatalf("New(proxy): want *ProxyAuth, got %T", a)
+	}
+	if pa.UserHeader != "X-Forwarded-User" || pa.EmailHeader != "X-Forwarded-Email" {
+		t.Errorf("New(proxy): headers not propagated: %+v", pa)
+	}
+}
+
+func TestNew_ProxyRequiresUserHeader(t *testing.T) {
+	if _, err := auth.New(auth.ModeProxy, "", "X-Forwarded-Email"); err == nil {
+		t.Fatal("New(proxy, empty user header): expected error, got nil")
+	}
+}
+
+func TestNew_UnknownModeRejected(t *testing.T) {
+	if _, err := auth.New("jwt", "", ""); err == nil {
+		t.Fatal("New(jwt): expected error for unsupported mode, got nil")
+	}
+}
+
+func TestAnonymousAuth_AlwaysAnonymous(t *testing.T) {
+	a := &auth.AnonymousAuth{}
+	req := httptest.NewRequest("GET", "/", nil)
+	// Even if someone forges X-Auth-* on the way in, the strategy returns
+	// canonical anonymous. (The middleware is the layer that strips
+	// inbound headers before calling Authenticate.)
+	req.Header.Set("X-Auth-Subject", "evil")
+	req.Header.Set("X-Forwarded-User", "evil")
+
+	id, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: unexpected error: %v", err)
+	}
+	if id.Subject != "anonymous" || id.Mode != auth.ModeAnonymous {
+		t.Errorf("anonymous identity: got %+v", id)
+	}
+	if id.User != "" || id.Email != "" {
+		t.Errorf("anonymous identity should have empty User/Email, got %+v", id)
+	}
+}
+
+func TestProxyAuth_HappyPath(t *testing.T) {
+	p := &auth.ProxyAuth{
+		UserHeader:  "X-Forwarded-User",
+		EmailHeader: "X-Forwarded-Email",
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-User", "alice")
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	id, err := p.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: unexpected error: %v", err)
+	}
+	want := auth.Identity{
+		Subject: "alice",
+		User:    "alice",
+		Email:   "alice@example.com",
+		Mode:    auth.ModeProxy,
+	}
+	if id != want {
+		t.Errorf("proxy identity: got %+v, want %+v", id, want)
+	}
+}
+
+func TestProxyAuth_MissingUserHeaderFailsClosed(t *testing.T) {
+	p := &auth.ProxyAuth{
+		UserHeader:  "X-Forwarded-User",
+		EmailHeader: "X-Forwarded-Email",
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	// Email present but user missing — must error so the caller can
+	// return 503. Silent fallback to anonymous would mask a misconfigured
+	// proxy.
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	_, err := p.Authenticate(req)
+	if !errors.Is(err, auth.ErrMissingProxyHeaders) {
+		t.Fatalf("Authenticate: want ErrMissingProxyHeaders, got %v", err)
+	}
+}
+
+func TestProxyAuth_EmailOptional(t *testing.T) {
+	p := &auth.ProxyAuth{
+		UserHeader:  "X-Forwarded-User",
+		EmailHeader: "X-Forwarded-Email",
+	}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-User", "alice")
+
+	id, err := p.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: unexpected error: %v", err)
+	}
+	if id.Email != "" {
+		t.Errorf("expected empty email when header absent, got %q", id.Email)
+	}
+	if id.Subject != "alice" || id.User != "alice" {
+		t.Errorf("expected user=alice, got %+v", id)
+	}
+}
+
+func TestProxyAuth_EmptyEmailHeaderName(t *testing.T) {
+	// EmailHeader = "" means "this deployment doesn't surface email".
+	// Must not panic; identity has no email.
+	p := &auth.ProxyAuth{UserHeader: "X-Forwarded-User"}
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-User", "alice")
+	req.Header.Set("X-Forwarded-Email", "alice@example.com") // ignored
+
+	id, err := p.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: unexpected error: %v", err)
+	}
+	if id.Email != "" {
+		t.Errorf("expected empty email when EmailHeader unset, got %q", id.Email)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,6 +5,17 @@ import (
 	"net/http"
 )
 
+// unauthenticatedPaths are exempt from auth resolution. Kubelet liveness
+// and readiness probes hit the gateway directly (not through the upstream
+// OAuth proxy) and have no identity, so in proxy mode they would otherwise
+// fail closed and crash-loop the pod. The agent card is metadata and is
+// safe to expose anonymously.
+var unauthenticatedPaths = map[string]struct{}{
+	"/healthz":                 {},
+	"/readyz":                  {},
+	"/.well-known/agent.json":  {},
+}
+
 // Middleware returns an HTTP middleware that resolves caller identity using
 // the supplied Authenticator and projects it onto canonical X-Auth-*
 // headers. Inbound copies of the canonical headers are stripped before the
@@ -13,10 +24,20 @@ import (
 // On ErrMissingProxyHeaders the middleware returns 503 — fail-closed, since
 // a missing upstream identity in proxy mode means the deployment is
 // misconfigured.
+//
+// Probe and discovery paths (see unauthenticatedPaths) bypass the strategy
+// entirely. Inbound canonical headers are still stripped on those paths so
+// they cannot be used as a spoof channel into downstream handlers — but
+// since those handlers don't call any backend, this is defence in depth.
 func Middleware(a Authenticator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			stripCanonicalHeaders(r.Header)
+
+			if _, exempt := unauthenticatedPaths[r.URL.Path]; exempt {
+				next.ServeHTTP(w, r)
+				return
+			}
 
 			id, err := a.Authenticate(r)
 			if err != nil {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// Middleware returns an HTTP middleware that resolves caller identity using
+// the supplied Authenticator and projects it onto canonical X-Auth-*
+// headers. Inbound copies of the canonical headers are stripped before the
+// strategy runs so clients cannot spoof identity.
+//
+// On ErrMissingProxyHeaders the middleware returns 503 — fail-closed, since
+// a missing upstream identity in proxy mode means the deployment is
+// misconfigured.
+func Middleware(a Authenticator) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			stripCanonicalHeaders(r.Header)
+
+			id, err := a.Authenticate(r)
+			if err != nil {
+				slog.Error("auth: identity resolution failed",
+					"error", err,
+					"path", r.URL.Path,
+					"method", r.Method,
+				)
+				http.Error(w, `{"error":"upstream identity unavailable"}`, http.StatusServiceUnavailable)
+				return
+			}
+
+			setCanonicalHeaders(r.Header, id)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// stripCanonicalHeaders removes any inbound copies of the canonical X-Auth-*
+// headers so a client cannot pre-populate them.
+func stripCanonicalHeaders(h http.Header) {
+	for _, name := range CanonicalHeaders {
+		h.Del(name)
+	}
+}
+
+// setCanonicalHeaders writes the canonical headers from id onto h. Empty
+// fields are still written (as empty strings) so downstream handlers see a
+// uniform contract.
+func setCanonicalHeaders(h http.Header, id Identity) {
+	h.Set(HeaderSubject, id.Subject)
+	h.Set(HeaderUser, id.User)
+	h.Set(HeaderEmail, id.Email)
+	h.Set(HeaderMode, id.Mode)
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,146 @@
+package auth_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fips-agents/gateway-template/internal/auth"
+)
+
+// captureHandler records the headers of the request that reaches it so
+// tests can assert on what the middleware projected.
+type captureHandler struct {
+	got http.Header
+}
+
+func (c *captureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.got = r.Header.Clone()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func TestMiddleware_AnonymousProjectsCanonicalHeaders(t *testing.T) {
+	cap := &captureHandler{}
+	mw := auth.Middleware(&auth.AnonymousAuth{})
+	h := mw(cap)
+
+	req := httptest.NewRequest("POST", "/v1/feedback", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204", rec.Code)
+	}
+	if got := cap.got.Get(auth.HeaderSubject); got != "anonymous" {
+		t.Errorf("X-Auth-Subject: got %q, want %q", got, "anonymous")
+	}
+	if got := cap.got.Get(auth.HeaderMode); got != auth.ModeAnonymous {
+		t.Errorf("X-Auth-Mode: got %q, want %q", got, auth.ModeAnonymous)
+	}
+}
+
+func TestMiddleware_StripsInboundSpoofedHeaders(t *testing.T) {
+	cap := &captureHandler{}
+	mw := auth.Middleware(&auth.AnonymousAuth{})
+	h := mw(cap)
+
+	req := httptest.NewRequest("POST", "/v1/feedback", nil)
+	// Client tries to forge identity. Middleware must replace these with
+	// the strategy's resolved identity.
+	req.Header.Set("X-Auth-Subject", "evil-admin")
+	req.Header.Set("X-Auth-User", "evil")
+	req.Header.Set("X-Auth-Email", "evil@example.com")
+	req.Header.Set("X-Auth-Mode", "proxy")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := cap.got.Get(auth.HeaderSubject); got != "anonymous" {
+		t.Errorf("forged X-Auth-Subject leaked through: got %q", got)
+	}
+	if got := cap.got.Get(auth.HeaderMode); got != auth.ModeAnonymous {
+		t.Errorf("forged X-Auth-Mode leaked through: got %q", got)
+	}
+	if got := cap.got.Get(auth.HeaderUser); got != "" {
+		t.Errorf("forged X-Auth-User leaked through: got %q", got)
+	}
+	if got := cap.got.Get(auth.HeaderEmail); got != "" {
+		t.Errorf("forged X-Auth-Email leaked through: got %q", got)
+	}
+}
+
+func TestMiddleware_ProxyModeProjectsUpstreamIdentity(t *testing.T) {
+	cap := &captureHandler{}
+	pa := &auth.ProxyAuth{UserHeader: "X-Forwarded-User", EmailHeader: "X-Forwarded-Email"}
+	h := auth.Middleware(pa)(cap)
+
+	req := httptest.NewRequest("POST", "/v1/feedback", nil)
+	req.Header.Set("X-Forwarded-User", "alice")
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := cap.got.Get(auth.HeaderSubject); got != "alice" {
+		t.Errorf("X-Auth-Subject: got %q, want alice", got)
+	}
+	if got := cap.got.Get(auth.HeaderUser); got != "alice" {
+		t.Errorf("X-Auth-User: got %q, want alice", got)
+	}
+	if got := cap.got.Get(auth.HeaderEmail); got != "alice@example.com" {
+		t.Errorf("X-Auth-Email: got %q, want alice@example.com", got)
+	}
+	if got := cap.got.Get(auth.HeaderMode); got != auth.ModeProxy {
+		t.Errorf("X-Auth-Mode: got %q, want proxy", got)
+	}
+}
+
+func TestMiddleware_ProxyModeFailsClosedOn503(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	pa := &auth.ProxyAuth{UserHeader: "X-Forwarded-User"}
+	h := auth.Middleware(pa)(next)
+
+	req := httptest.NewRequest("POST", "/v1/feedback", nil)
+	// No X-Forwarded-User → ErrMissingProxyHeaders.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", rec.Code)
+	}
+	if called {
+		t.Error("downstream handler ran despite auth failure")
+	}
+}
+
+// TestMiddleware_StubError ensures that any non-nil error from the
+// authenticator (not just ErrMissingProxyHeaders) causes a 503.
+func TestMiddleware_AnyAuthErrorReturns503(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	stub := stubAuth{err: errors.New("boom")}
+	h := auth.Middleware(stub)(next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", rec.Code)
+	}
+	if called {
+		t.Error("downstream handler ran despite auth error")
+	}
+}
+
+type stubAuth struct {
+	id  auth.Identity
+	err error
+}
+
+func (s stubAuth) Authenticate(*http.Request) (auth.Identity, error) {
+	return s.id, s.err
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -116,6 +116,42 @@ func TestMiddleware_ProxyModeFailsClosedOn503(t *testing.T) {
 	}
 }
 
+func TestMiddleware_HealthProbesBypassAuth(t *testing.T) {
+	// In proxy mode the kubelet's liveness/readiness probes hit the
+	// gateway directly with no X-Forwarded-User, which would otherwise
+	// trip ErrMissingProxyHeaders → 503 → crash loop. The middleware
+	// must let probe paths through unauthenticated.
+	cap := &captureHandler{}
+	pa := &auth.ProxyAuth{UserHeader: "X-Forwarded-User"}
+	h := auth.Middleware(pa)(cap)
+
+	for _, path := range []string{"/healthz", "/readyz", "/.well-known/agent.json"} {
+		req := httptest.NewRequest("GET", path, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusServiceUnavailable {
+			t.Errorf("path %q: probe path should bypass auth, got 503", path)
+		}
+	}
+}
+
+func TestMiddleware_HealthProbesStillStripSpoofedHeaders(t *testing.T) {
+	// Probe paths bypass the strategy but must still strip inbound
+	// X-Auth-* so they can't be used as a spoof channel.
+	cap := &captureHandler{}
+	h := auth.Middleware(&auth.AnonymousAuth{})(cap)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	req.Header.Set("X-Auth-Subject", "evil")
+	req.Header.Set("X-Auth-User", "evil")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := cap.got.Get("X-Auth-Subject"); got != "" {
+		t.Errorf("inbound X-Auth-Subject leaked through probe path: got %q", got)
+	}
+}
+
 // TestMiddleware_StubError ensures that any non-nil error from the
 // authenticator (not just ErrMissingProxyHeaders) causes a 503.
 func TestMiddleware_AnyAuthErrorReturns503(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,16 +13,30 @@ type Config struct {
 	AgentName    string
 	AgentVersion string
 	LogRequests  bool
+
+	// AuthMode selects the inbound auth strategy: "anonymous" (default)
+	// or "proxy". See internal/auth.
+	AuthMode string
+	// AuthProxyUserHeader is the upstream-projected username header
+	// consulted in proxy mode. Defaults to "X-Forwarded-User"
+	// (oauth-proxy convention).
+	AuthProxyUserHeader string
+	// AuthProxyEmailHeader is the upstream-projected email header. Empty
+	// means the deployment does not surface email.
+	AuthProxyEmailHeader string
 }
 
 // Load reads configuration from environment variables and validates required fields.
 func Load() (*Config, error) {
 	cfg := &Config{
-		Port:         envOrDefault("PORT", "8080"),
-		BackendURL:   os.Getenv("BACKEND_URL"),
-		AgentName:    envOrDefault("AGENT_NAME", "gateway-template"),
-		AgentVersion: envOrDefault("AGENT_VERSION", "0.1.0"),
-		LogRequests:  envBool("LOG_REQUESTS"),
+		Port:                 envOrDefault("PORT", "8080"),
+		BackendURL:           os.Getenv("BACKEND_URL"),
+		AgentName:            envOrDefault("AGENT_NAME", "gateway-template"),
+		AgentVersion:         envOrDefault("AGENT_VERSION", "0.1.0"),
+		LogRequests:          envBool("LOG_REQUESTS"),
+		AuthMode:             envOrDefault("GATEWAY_AUTH_MODE", "anonymous"),
+		AuthProxyUserHeader:  envOrDefault("GATEWAY_AUTH_PROXY_USER_HEADER", "X-Forwarded-User"),
+		AuthProxyEmailHeader: envOrDefault("GATEWAY_AUTH_PROXY_EMAIL_HEADER", "X-Forwarded-Email"),
 	}
 
 	if cfg.BackendURL == "" {

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -44,9 +44,9 @@ func (h *ChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if envelope.Stream {
-		h.proxyStreaming(w, body)
+		h.proxyStreaming(w, r, body)
 	} else {
-		h.proxySync(w, body)
+		h.proxySync(w, r, body)
 	}
 }
 
@@ -67,8 +67,8 @@ func copyPassThroughHeaders(dst http.Header, src http.Header) {
 }
 
 // proxySync forwards the request and returns the full backend response.
-func (h *ChatHandler) proxySync(w http.ResponseWriter, body []byte) {
-	resp, err := h.doBackendRequest(body)
+func (h *ChatHandler) proxySync(w http.ResponseWriter, r *http.Request, body []byte) {
+	resp, err := h.doBackendRequest(r, body)
 	if err != nil {
 		slog.Error("backend request failed", "error", err)
 		http.Error(w, `{"error":"backend request failed"}`, http.StatusBadGateway)
@@ -86,8 +86,8 @@ func (h *ChatHandler) proxySync(w http.ResponseWriter, body []byte) {
 
 // proxyStreaming connects to the backend with streaming enabled and relays
 // SSE chunks to the client.
-func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, body []byte) {
-	resp, err := h.doBackendRequest(body)
+func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, r *http.Request, body []byte) {
+	resp, err := h.doBackendRequest(r, body)
 	if err != nil {
 		slog.Error("backend streaming request failed", "error", err)
 		http.Error(w, `{"error":"backend request failed"}`, http.StatusBadGateway)
@@ -112,14 +112,30 @@ func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, body []byte) {
 	proxy.RelaySSE(resp, w)
 }
 
-// doBackendRequest sends the request body to the backend's chat completions endpoint.
-func (h *ChatHandler) doBackendRequest(body []byte) (*http.Response, error) {
+// forwardedAuthHeaders are the canonical X-Auth-* headers projected by the
+// auth middleware and forwarded to the backend agent.
+var forwardedAuthHeaders = []string{
+	"X-Auth-Subject",
+	"X-Auth-User",
+	"X-Auth-Email",
+	"X-Auth-Mode",
+}
+
+// doBackendRequest sends the request body to the backend's chat completions
+// endpoint, forwarding the canonical X-Auth-* headers from the inbound
+// request so the agent can attribute the call to the resolved identity.
+func (h *ChatHandler) doBackendRequest(r *http.Request, body []byte) (*http.Response, error) {
 	url := h.BackendURL + "/v1/chat/completions"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	for _, name := range forwardedAuthHeaders {
+		if v := r.Header.Get(name); v != "" {
+			req.Header.Set(name, v)
+		}
+	}
 
 	return h.Client.Do(req)
 }

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -257,6 +257,49 @@ func TestChatHandler_PropagatesXTraceIdHeader(t *testing.T) {
 	}
 }
 
+func TestChatHandler_ForwardsCanonicalAuthHeaders(t *testing.T) {
+	var captured http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"chatcmpl-x"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.ChatHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	// The auth middleware would normally set these. Tests bypass the
+	// middleware so we set them directly to assert forwarding.
+	reqBody := `{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-Subject", "alice")
+	req.Header.Set("X-Auth-User", "alice")
+	req.Header.Set("X-Auth-Email", "alice@example.com")
+	req.Header.Set("X-Auth-Mode", "proxy")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if got := captured.Get("X-Auth-Subject"); got != "alice" {
+		t.Errorf("X-Auth-Subject not forwarded: got %q", got)
+	}
+	if got := captured.Get("X-Auth-User"); got != "alice" {
+		t.Errorf("X-Auth-User not forwarded: got %q", got)
+	}
+	if got := captured.Get("X-Auth-Email"); got != "alice@example.com" {
+		t.Errorf("X-Auth-Email not forwarded: got %q", got)
+	}
+	if got := captured.Get("X-Auth-Mode"); got != "proxy" {
+		t.Errorf("X-Auth-Mode not forwarded: got %q", got)
+	}
+}
+
 func TestChatHandler_StreamingBackendError(t *testing.T) {
 	// Backend returns 500 on a streaming request -- gateway should forward the
 	// error status rather than switching to SSE mode.

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 )
 
-// authHeaders are the request headers forwarded to the backend so it can
-// attribute feedback to the calling user. Other headers are dropped.
+// authHeaders are the canonical X-Auth-* headers forwarded to the backend so
+// it can attribute feedback to the calling user. The auth middleware
+// populates these from the resolved Identity; inbound spoofed copies are
+// stripped before any handler runs. Other headers are dropped.
 var authHeaders = []string{
-	"Authorization",
-	"X-User-ID",
-	"X-Forwarded-User",
+	"X-Auth-Subject",
+	"X-Auth-User",
+	"X-Auth-Email",
+	"X-Auth-Mode",
 }
 
 // FeedbackHandler proxies user feedback API requests to the backend agent

--- a/internal/handler/feedback_test.go
+++ b/internal/handler/feedback_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestFeedbackHandler_PostProxy(t *testing.T) {
 	var capturedBody []byte
-	var capturedAuth string
-	var capturedUser string
+	var capturedSubject, capturedUser, capturedEmail, capturedMode string
+	var capturedAuthorization, capturedXUserID string
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -24,8 +24,12 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 			t.Errorf("backend: want path /v1/feedback, got %s", r.URL.Path)
 		}
 		capturedBody, _ = io.ReadAll(r.Body)
-		capturedAuth = r.Header.Get("Authorization")
-		capturedUser = r.Header.Get("X-User-ID")
+		capturedSubject = r.Header.Get("X-Auth-Subject")
+		capturedUser = r.Header.Get("X-Auth-User")
+		capturedEmail = r.Header.Get("X-Auth-Email")
+		capturedMode = r.Header.Get("X-Auth-Mode")
+		capturedAuthorization = r.Header.Get("Authorization")
+		capturedXUserID = r.Header.Get("X-User-ID")
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -38,9 +42,18 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 		Client:     backend.Client(),
 	}
 
+	// The auth middleware would normally project these from the resolved
+	// Identity. Tests bypass the middleware so we set them directly to
+	// assert that the gateway forwards canonical headers and drops the
+	// pre-cutover ones.
 	reqBody := `{"trace_id":"tr_1","rating":1,"comment":"great"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-Subject", "alice")
+	req.Header.Set("X-Auth-User", "alice")
+	req.Header.Set("X-Auth-Email", "alice@example.com")
+	req.Header.Set("X-Auth-Mode", "proxy")
+	// Pre-cutover headers — must be dropped, not forwarded.
 	req.Header.Set("Authorization", "Bearer secret-token")
 	req.Header.Set("X-User-ID", "user-42")
 	rec := httptest.NewRecorder()
@@ -53,11 +66,23 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 	if string(capturedBody) != reqBody {
 		t.Errorf("post proxy: want body %q forwarded, got %q", reqBody, string(capturedBody))
 	}
-	if capturedAuth != "Bearer secret-token" {
-		t.Errorf("post proxy: Authorization header not forwarded, got %q", capturedAuth)
+	if capturedSubject != "alice" {
+		t.Errorf("X-Auth-Subject not forwarded: got %q", capturedSubject)
 	}
-	if capturedUser != "user-42" {
-		t.Errorf("post proxy: X-User-ID header not forwarded, got %q", capturedUser)
+	if capturedUser != "alice" {
+		t.Errorf("X-Auth-User not forwarded: got %q", capturedUser)
+	}
+	if capturedEmail != "alice@example.com" {
+		t.Errorf("X-Auth-Email not forwarded: got %q", capturedEmail)
+	}
+	if capturedMode != "proxy" {
+		t.Errorf("X-Auth-Mode not forwarded: got %q", capturedMode)
+	}
+	if capturedAuthorization != "" {
+		t.Errorf("Authorization header should be dropped, got %q", capturedAuthorization)
+	}
+	if capturedXUserID != "" {
+		t.Errorf("X-User-ID header should be dropped, got %q", capturedXUserID)
 	}
 
 	var got map[string]any

--- a/llms.txt
+++ b/llms.txt
@@ -8,12 +8,13 @@ This is a template repository. The sentinel string `gateway-template` is replace
 
 - [README](https://raw.githubusercontent.com/fips-agents/gateway-template/main/README.md): Project overview, configuration variables, endpoints, and deployment instructions
 - [Server entrypoint](https://raw.githubusercontent.com/fips-agents/gateway-template/main/cmd/server/main.go): HTTP mux wiring, graceful shutdown, route registration
-- [Config](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/config/config.go): Environment variable parsing (BACKEND_URL, PORT, AGENT_NAME, AGENT_VERSION, LOG_REQUESTS)
+- [Config](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/config/config.go): Environment variable parsing (BACKEND_URL, PORT, AGENT_NAME, AGENT_VERSION, LOG_REQUESTS, GATEWAY_AUTH_MODE, GATEWAY_AUTH_PROXY_USER_HEADER, GATEWAY_AUTH_PROXY_EMAIL_HEADER)
 
 ## Handlers
 
 - [Chat completions](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/chat.go): POST /v1/chat/completions — sync and SSE streaming proxy
-- [Feedback](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/feedback.go): POST/GET /v1/feedback and GET /v1/feedback/stats — pass-through with auth header forwarding
+- [Feedback](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/feedback.go): POST/GET /v1/feedback, PATCH /v1/feedback/{id}, GET /v1/feedback/stats — pass-through; forwards canonical X-Auth-* headers
+- [Auth](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/auth/auth.go): Inbound auth strategies (anonymous, proxy) and middleware that projects identity onto canonical X-Auth-Subject / X-Auth-User / X-Auth-Email / X-Auth-Mode headers
 - [Health](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/health.go): GET /healthz and /readyz endpoints
 - [Agent card](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/wellknown.go): GET /.well-known/agent.json
 


### PR DESCRIPTION
## Summary

Implements v1 of #21. The gateway now resolves caller identity at the edge and projects it onto a canonical, gateway-issued header contract that the backend agent can rely on:

```
X-Auth-Subject: <stable id — "anonymous" or upstream-validated user>
X-Auth-User:    <human-readable username>
X-Auth-Email:   <email or empty>
X-Auth-Mode:    anonymous | proxy
```

Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's JWT claim shape (\`sub\`, \`email\`) so the contract survives a future swap to in-process JWKS / AuthBridge without breaking the agent.

Two strategies wired via \`GATEWAY_AUTH_MODE\`:

- **\`anonymous\`** *(default)* — no validation. \`X-Auth-Subject="anonymous"\`. Smoke script and local dev unchanged.
- **\`proxy\`** — trust upstream OAuth proxy (or service-mesh \`outputClaimToHeaders\`). Reads \`X-Forwarded-User\`/\`X-Forwarded-Email\` (configurable via \`GATEWAY_AUTH_PROXY_USER_HEADER\` / \`GATEWAY_AUTH_PROXY_EMAIL_HEADER\`). **Fails closed with 503** when the user header is missing — a misconfigured proxy must not silently degrade to anonymous.

\`jwt\` mode (in-process JWKS validation) and token exchange to MCP/tools are deferred to v2; will file a follow-up issue once this lands.

## Notable changes

- New \`internal/auth/\` package — \`Authenticator\` interface, \`AnonymousAuth\`/\`ProxyAuth\` strategies, edge middleware that strips inbound \`X-Auth-*\` and projects canonical headers.
- \`internal/handler/feedback.go\` allowlist swap: \`Authorization\` / \`X-User-ID\` / \`X-Forwarded-User\` → the four \`X-Auth-*\` headers.
- \`internal/handler/chat.go\` now also forwards the canonical headers (it forwarded no inbound headers before).
- Helm chart picks up \`auth.mode\`, \`auth.proxy.userHeader\`, \`auth.proxy.emailHeader\`.

This PR is **stacked on \`feat/feedback-routes\` (#20)**. Merge after #20.

## Cutover

Hard cutover for the agent — feedback PRs (agent #109/#110/#111, ui #23) haven't shipped yet, so the agent will read \`X-Auth-Subject\` directly with no \`X-User-ID\` migration window. Companion PRs to follow in this same series.

## Test plan

- [x] \`go test ./...\` (auth pkg + handler pkg, including new forwarding/spoof-strip assertions)
- [x] \`go vet ./...\`
- [x] \`helm template chart/\` renders the new env vars
- [ ] End-to-end smoke (\`scripts/smoke-feedback.sh\` in agent-template) once the agent #109 cutover lands — should stay green in anonymous mode
- [ ] Cluster test in \`proxy\` mode (oauth-proxy in front of gateway, verify \`X-Auth-*\` reaches the agent)