### PR TITLE
auth: Add jwt mode (in-process JWKS validation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ make image-build
 
 ## Architecture
 
-This is a thin reverse proxy -- no business logic, no external dependencies. All code uses the Go standard library only.
+This is a thin reverse proxy -- minimal external dependencies. The core proxy and auth middleware use the Go standard library only; the `jwt` auth mode adds two stdlib-crypto-only third-party deps (`github.com/golang-jwt/jwt/v5`, `github.com/MicahParks/keyfunc/v3`) to validate inbound bearer tokens against a JWKS endpoint. Both libraries route through Go's FIPS-certified crypto module when the binary is built with FIPS enabled.
 
 ```
 Client --> Gateway (:8080) --> Backend Agent
@@ -45,7 +45,7 @@ Key packages:
 - `internal/config/` -- environment variable parsing
 - `internal/handler/` -- HTTP handlers for each route
 - `internal/middleware/` -- request logging (structured, skips health probes)
-- `internal/auth/` -- inbound auth strategies (`anonymous`, `proxy`) + middleware that strips spoofed `X-Auth-*` headers and projects canonical identity onto the request
+- `internal/auth/` -- inbound auth strategies (`anonymous`, `proxy`, `jwt`) + middleware that strips spoofed `X-Auth-*` headers and projects canonical identity onto the request. `jwt` mode validates `Authorization: Bearer <token>` against a configured JWKS endpoint (cached by `kid`), enforces `iss`/`aud`/`exp`/`nbf`, and maps invalid tokens → 401 vs. JWKS-cold-cache failures → 503
 - `internal/proxy/` -- SSE relay logic
 
 ## Configuration
@@ -57,13 +57,30 @@ Key packages:
 | `AGENT_NAME` | No | `gateway-template` | Name in agent card |
 | `AGENT_VERSION` | No | `0.1.0` | Version in agent card |
 | `LOG_REQUESTS` | No | `false` | Enable structured request logging |
-| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous` or `proxy` |
+| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous`, `proxy`, or `jwt` |
 | `GATEWAY_AUTH_PROXY_USER_HEADER` | No | `X-Forwarded-User` | (`proxy` mode) upstream-validated username header |
 | `GATEWAY_AUTH_PROXY_EMAIL_HEADER` | No | `X-Forwarded-Email` | (`proxy` mode) upstream-validated email header |
+| `GATEWAY_AUTH_JWT_JWKS_URL` | jwt mode | -- | (`jwt` mode) JWKS endpoint URL |
+| `GATEWAY_AUTH_JWT_ISSUER` | jwt mode | -- | (`jwt` mode) expected `iss` claim |
+| `GATEWAY_AUTH_JWT_AUDIENCE` | jwt mode | -- | (`jwt` mode) expected `aud` claim |
+| `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim → `X-Auth-Subject` |
+| `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim → `X-Auth-User` |
+| `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim → `X-Auth-Email` |
 
 ## Auth contract
 
-The gateway emits canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers to the backend on every `/v1/*` request. Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's JWT claim shape so the contract survives a future swap to in-process JWKS validation. `proxy` mode fails closed with 503 when the upstream user header is missing. `jwt` mode (in-process JWKS) is deferred to v2.
+The gateway emits canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers to the backend on every `/v1/*` request. Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's AuthBridge JWT claim shape, so an AuthBridge token and a fipsagents-issued token resolve onto the same canonical contract. `proxy` mode fails closed with 503 when the upstream user header is missing. `jwt` mode validates `Authorization: Bearer <token>` against a JWKS endpoint, returning 401 on bad/expired/wrong-issuer/wrong-audience tokens and 503 only when the JWKS endpoint is unreachable AND the cache is cold. Token-exchange (RFC 8693) for downstream MCP/tool calls is deferred to a follow-up.
+
+### Live integration test
+
+`internal/auth/jwt_keycloak_integration_test.go` is build-tagged `integration` and exercises `jwt` mode against a real Keycloak. To run:
+
+```bash
+eval "$(scripts/keycloak-test-setup.sh)"   # bootstraps a clean realm/client/user
+go test -tags integration -run TestJWTAuth_LiveKeycloak ./internal/auth/...
+```
+
+The setup script targets the keycloak operator instance in the `keycloak` namespace of the `mcp-rhoai` cluster (overridable via `KC_CONTEXT` / `KC_NAMESPACE`). Without `KC_INTEGRATION=1` the tests skip, so CI without cluster access stays green.
 
 ## Deployment
 

--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,8 @@
 FROM registry.redhat.io/ubi9/go-toolset:1.22 AS builder
 
 WORKDIR /opt/app-root/src
-COPY go.mod ./
+COPY go.mod go.sum ./
+RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
 RUN go build -o ./gateway ./cmd/server

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gateway-template
 
-An OpenAI-compatible HTTP reverse proxy for AI agent backends. It accepts `/v1/chat/completions` requests (synchronous and SSE streaming), proxies them to a configurable backend agent service, and handles the SSE connection lifecycle including heartbeats and flush. Built with the Go standard library only -- no external dependencies.
+An OpenAI-compatible HTTP reverse proxy for AI agent backends. It accepts `/v1/chat/completions` requests (synchronous and SSE streaming), proxies them to a configurable backend agent service, and handles the SSE connection lifecycle including heartbeats and flush. Built primarily on the Go standard library; the only third-party dependencies are the JWT/JWKS libraries used by `jwt` auth mode (both stdlib-crypto-only, FIPS-compatible).
 
 ## Quick Start
 
@@ -24,9 +24,15 @@ curl http://localhost:8080/healthz
 | `AGENT_NAME` | No | `gateway-template` | Agent name in `/.well-known/agent.json` |
 | `AGENT_VERSION` | No | `0.1.0` | Agent version in `/.well-known/agent.json` |
 | `LOG_REQUESTS` | No | `false` | Enable structured request logging (skips health probes) |
-| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous` or `proxy` |
+| `GATEWAY_AUTH_MODE` | No | `anonymous` | Inbound auth strategy: `anonymous`, `proxy`, or `jwt` |
 | `GATEWAY_AUTH_PROXY_USER_HEADER` | No | `X-Forwarded-User` | (`proxy` mode) header carrying the upstream-validated username |
 | `GATEWAY_AUTH_PROXY_EMAIL_HEADER` | No | `X-Forwarded-Email` | (`proxy` mode) header carrying the upstream-validated email; empty disables email projection |
+| `GATEWAY_AUTH_JWT_JWKS_URL` | jwt mode | -- | (`jwt` mode) URL of the JWKS endpoint, e.g. `https://kc/realms/x/protocol/openid-connect/certs` |
+| `GATEWAY_AUTH_JWT_ISSUER` | jwt mode | -- | (`jwt` mode) expected `iss` claim |
+| `GATEWAY_AUTH_JWT_AUDIENCE` | jwt mode | -- | (`jwt` mode) expected `aud` claim |
+| `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim to project onto `X-Auth-Subject` |
+| `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim to project onto `X-Auth-User` |
+| `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim to project onto `X-Auth-Email` |
 
 ## Authentication
 
@@ -37,14 +43,23 @@ The gateway issues a canonical set of trusted headers to the backend agent on ev
 | `X-Auth-Subject` | Stable identifier (`anonymous` or the upstream-validated username) |
 | `X-Auth-User` | Human-readable username (may be empty in `anonymous` mode) |
 | `X-Auth-Email` | Email address (may be empty) |
-| `X-Auth-Mode` | `anonymous` or `proxy` |
+| `X-Auth-Mode` | `anonymous`, `proxy`, or `jwt` |
 
-Inbound copies of these headers are stripped before the strategy runs, so a client cannot spoof identity by setting them directly. The header names match Kagenti's JWT claim shape so the contract survives a future swap to in-process JWKS validation without breaking the agent.
+Inbound copies of these headers are stripped before the strategy runs, so a client cannot spoof identity by setting them directly. The header names match Kagenti's JWT claim shape, so an AuthBridge token and a fipsagents-issued token resolve onto the same canonical contract.
 
 **Modes** (`GATEWAY_AUTH_MODE`):
 
 - `anonymous` *(default)* — no validation. `X-Auth-Subject` is set to `anonymous`. Use for local dev, smoke tests, or any deployment that does not need user attribution.
-- `proxy` — trust an upstream OAuth proxy (e.g. OpenShift `oauth-proxy` sidecar) or service-mesh `outputClaimToHeaders` filter. The gateway reads `X-Forwarded-User` / `X-Forwarded-Email` (header names configurable) and projects them onto the canonical headers. **The gateway pod must be unreachable except via that proxy** — otherwise a client can spoof the upstream headers. If the user header is missing, the gateway returns 503 (fail closed). In-process JWKS validation is deferred to v2.
+- `proxy` — trust an upstream OAuth proxy (e.g. OpenShift `oauth-proxy` sidecar) or service-mesh `outputClaimToHeaders` filter. The gateway reads `X-Forwarded-User` / `X-Forwarded-Email` (header names configurable) and projects them onto the canonical headers. **The gateway pod must be unreachable except via that proxy** — otherwise a client can spoof the upstream headers. If the user header is missing, the gateway returns 503 (fail closed).
+- `jwt` — in-process bearer-token validation against a JWKS endpoint. The gateway reads `Authorization: Bearer <token>`, validates the signature against keys fetched from `GATEWAY_AUTH_JWT_JWKS_URL` (cached by `kid`), enforces `iss`, `aud`, `exp`, `nbf`, and projects the configured claims onto the canonical headers. Returns 401 on invalid/expired/wrong-issuer/wrong-audience tokens, 503 if the JWKS endpoint is unreachable AND the cache is cold. Use this when there is no OAuth proxy in front of the gateway (self-contained deployments, or anywhere clients can present tokens directly). Only RSA / ECDSA / RSA-PSS signatures are accepted; HMAC and `alg=none` are rejected by construction.
+
+**Choosing a mode:**
+
+- Behind an OpenShift `oauth-proxy` sidecar or a service-mesh authn filter → `proxy`.
+- Self-contained gateway exposed to clients that already hold a JWT (Keycloak, Auth0, Cognito, Azure AD, etc.) → `jwt`.
+- Local development or smoke tests → `anonymous`.
+
+**FIPS:** the JWT/JWKS implementation uses Go stdlib crypto only (no third-party crypto), so it routes through Go's FIPS module when the binary is built with `GOFIPS140=on` (Go ≥1.24) or `GOEXPERIMENT=boringcrypto` (Go ≤1.23).
 
 ## Endpoints
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -11,3 +11,11 @@ data:
   GATEWAY_AUTH_MODE: {{ .Values.auth.mode | quote }}
   GATEWAY_AUTH_PROXY_USER_HEADER: {{ .Values.auth.proxy.userHeader | quote }}
   GATEWAY_AUTH_PROXY_EMAIL_HEADER: {{ .Values.auth.proxy.emailHeader | quote }}
+  {{- if eq .Values.auth.mode "jwt" }}
+  GATEWAY_AUTH_JWT_JWKS_URL: {{ required "auth.jwt.jwksUrl is required when auth.mode=jwt" .Values.auth.jwt.jwksUrl | quote }}
+  GATEWAY_AUTH_JWT_ISSUER: {{ required "auth.jwt.issuer is required when auth.mode=jwt" .Values.auth.jwt.issuer | quote }}
+  GATEWAY_AUTH_JWT_AUDIENCE: {{ required "auth.jwt.audience is required when auth.mode=jwt" .Values.auth.jwt.audience | quote }}
+  GATEWAY_AUTH_JWT_SUBJECT_CLAIM: {{ .Values.auth.jwt.subjectClaim | default "sub" | quote }}
+  GATEWAY_AUTH_JWT_USER_CLAIM: {{ .Values.auth.jwt.userClaim | default "preferred_username" | quote }}
+  GATEWAY_AUTH_JWT_EMAIL_CLAIM: {{ .Values.auth.jwt.emailClaim | default "email" | quote }}
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,7 +16,7 @@ resources:
 config:
   BACKEND_URL: http://my-agent:8080
 
-# Inbound auth strategy. See internal/auth and gateway-template#21.
+# Inbound auth strategy. See internal/auth and gateway-template#21 / #23.
 #   anonymous (default) — no validation, X-Auth-Subject is "anonymous".
 #                         Use for local dev, smoke tests, or any deployment
 #                         that does not need user attribution.
@@ -25,11 +25,32 @@ config:
 #                         X-Forwarded-User / X-Forwarded-Email. The
 #                         gateway pod MUST be unreachable except via that
 #                         proxy, otherwise headers can be spoofed.
+#   jwt                 — in-process JWT validation against a JWKS endpoint.
+#                         Use when there is no OAuth proxy in front of the
+#                         gateway (self-contained deployments). The gateway
+#                         validates Authorization: Bearer <token> against
+#                         auth.jwt.jwksUrl, projects the claims onto the
+#                         canonical X-Auth-* headers.
 auth:
   mode: anonymous
   proxy:
     userHeader: X-Forwarded-User
     emailHeader: X-Forwarded-Email
+  jwt:
+    # JWKS endpoint to fetch signing keys from. Required when mode=jwt.
+    # Example: https://keycloak.example/realms/myrealm/protocol/openid-connect/certs
+    jwksUrl: ""
+    # Expected `iss` claim. Required when mode=jwt.
+    # Example: https://keycloak.example/realms/myrealm
+    issuer: ""
+    # Expected `aud` claim. Required when mode=jwt.
+    audience: ""
+    # Claim name to project onto X-Auth-Subject. Default: sub.
+    subjectClaim: sub
+    # Claim name to project onto X-Auth-User. Default: preferred_username.
+    userClaim: preferred_username
+    # Claim name to project onto X-Auth-Email. Default: email.
+    emailClaim: email
 
 service:
   port: 8080

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,7 +26,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	authenticator, err := auth.New(cfg.AuthMode, cfg.AuthProxyUserHeader, cfg.AuthProxyEmailHeader)
+	authenticator, err := auth.New(cfg.AuthMode, auth.Options{
+		ProxyUserHeader:  cfg.AuthProxyUserHeader,
+		ProxyEmailHeader: cfg.AuthProxyEmailHeader,
+		JWT: auth.JWTConfig{
+			JWKSURL:      cfg.AuthJWTJWKSURL,
+			Issuer:       cfg.AuthJWTIssuer,
+			Audience:     cfg.AuthJWTAudience,
+			SubjectClaim: cfg.AuthJWTSubjectClaim,
+			UserClaim:    cfg.AuthJWTUserClaim,
+			EmailClaim:   cfg.AuthJWTEmailClaim,
+		},
+	})
 	if err != nil {
 		slog.Error("auth configuration error", "error", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,13 @@
 module github.com/fips-agents/gateway-template
 
 go 1.22
+
+require (
+	github.com/MicahParks/keyfunc/v3 v3.8.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
+)
+
+require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,6 +23,7 @@ import (
 const (
 	ModeAnonymous = "anonymous"
 	ModeProxy     = "proxy"
+	ModeJWT       = "jwt"
 )
 
 // Canonical header names emitted to the backend.
@@ -62,22 +63,34 @@ type Authenticator interface {
 	Authenticate(r *http.Request) (Identity, error)
 }
 
-// New returns the authenticator for the given mode. userHeader and
-// emailHeader are only consulted in proxy mode.
-func New(mode, userHeader, emailHeader string) (Authenticator, error) {
+// Options bundles every parameter New() may consume. Each field is only
+// consulted by the corresponding mode; unused fields are ignored.
+type Options struct {
+	// ProxyUserHeader / ProxyEmailHeader are consulted only in proxy mode.
+	ProxyUserHeader  string
+	ProxyEmailHeader string
+
+	// JWT is consulted only in jwt mode.
+	JWT JWTConfig
+}
+
+// New returns the authenticator for the given mode.
+func New(mode string, opts Options) (Authenticator, error) {
 	switch mode {
 	case ModeAnonymous, "":
 		return &AnonymousAuth{}, nil
 	case ModeProxy:
-		if userHeader == "" {
+		if opts.ProxyUserHeader == "" {
 			return nil, fmt.Errorf("auth: proxy mode requires a non-empty user header name")
 		}
 		return &ProxyAuth{
-			UserHeader:  userHeader,
-			EmailHeader: emailHeader,
+			UserHeader:  opts.ProxyUserHeader,
+			EmailHeader: opts.ProxyEmailHeader,
 		}, nil
+	case ModeJWT:
+		return NewJWTAuth(opts.JWT)
 	default:
-		return nil, fmt.Errorf("auth: unknown mode %q (want %q or %q)", mode, ModeAnonymous, ModeProxy)
+		return nil, fmt.Errorf("auth: unknown mode %q (want %q, %q, or %q)", mode, ModeAnonymous, ModeProxy, ModeJWT)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNew_DefaultsToAnonymous(t *testing.T) {
-	a, err := auth.New("", "", "")
+	a, err := auth.New("", auth.Options{})
 	if err != nil {
 		t.Fatalf("New(\"\"): unexpected error: %v", err)
 	}
@@ -19,7 +19,7 @@ func TestNew_DefaultsToAnonymous(t *testing.T) {
 }
 
 func TestNew_AnonymousMode(t *testing.T) {
-	a, err := auth.New(auth.ModeAnonymous, "", "")
+	a, err := auth.New(auth.ModeAnonymous, auth.Options{})
 	if err != nil {
 		t.Fatalf("New(anonymous): unexpected error: %v", err)
 	}
@@ -29,7 +29,10 @@ func TestNew_AnonymousMode(t *testing.T) {
 }
 
 func TestNew_ProxyMode(t *testing.T) {
-	a, err := auth.New(auth.ModeProxy, "X-Forwarded-User", "X-Forwarded-Email")
+	a, err := auth.New(auth.ModeProxy, auth.Options{
+		ProxyUserHeader:  "X-Forwarded-User",
+		ProxyEmailHeader: "X-Forwarded-Email",
+	})
 	if err != nil {
 		t.Fatalf("New(proxy): unexpected error: %v", err)
 	}
@@ -43,14 +46,22 @@ func TestNew_ProxyMode(t *testing.T) {
 }
 
 func TestNew_ProxyRequiresUserHeader(t *testing.T) {
-	if _, err := auth.New(auth.ModeProxy, "", "X-Forwarded-Email"); err == nil {
+	if _, err := auth.New(auth.ModeProxy, auth.Options{ProxyEmailHeader: "X-Forwarded-Email"}); err == nil {
 		t.Fatal("New(proxy, empty user header): expected error, got nil")
 	}
 }
 
 func TestNew_UnknownModeRejected(t *testing.T) {
-	if _, err := auth.New("jwt", "", ""); err == nil {
-		t.Fatal("New(jwt): expected error for unsupported mode, got nil")
+	if _, err := auth.New("garbage", auth.Options{}); err == nil {
+		t.Fatal("New(garbage): expected error for unsupported mode, got nil")
+	}
+}
+
+func TestNew_JWTRequiresJWKSURL(t *testing.T) {
+	if _, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{Issuer: "https://kc/realms/x", Audience: "gw"},
+	}); err == nil {
+		t.Fatal("New(jwt, missing JWKSURL): expected error, got nil")
 	}
 }
 

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,182 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ErrInvalidToken signals that the inbound bearer token failed validation
+// (bad signature, expired, wrong issuer/audience, malformed). The middleware
+// maps it to 401 — distinct from ErrMissingProxyHeaders / generic auth errors
+// which map to 503.
+var ErrInvalidToken = errors.New("auth: invalid bearer token")
+
+// ErrJWKSUnavailable signals that the JWKS endpoint could not be reached
+// and the cache is cold (no keys to validate against). The middleware maps
+// this to 503 — the deployment is degraded, not the caller's fault.
+var ErrJWKSUnavailable = errors.New("auth: JWKS endpoint unavailable and cache is cold")
+
+// JWTConfig is the parsed configuration for jwt mode. All fields are
+// required except SubjectClaim/UserClaim/EmailClaim, which default to
+// "sub" / "preferred_username" / "email".
+type JWTConfig struct {
+	JWKSURL      string
+	Issuer       string
+	Audience     string
+	SubjectClaim string
+	UserClaim    string
+	EmailClaim   string
+}
+
+// JWTAuth validates an inbound bearer token against a JWKS endpoint and
+// projects the resolved claims onto a canonical Identity.
+//
+// Validation rules:
+//   - Signature must verify against a key in the JWKS (matched by `kid`).
+//   - `exp` must be in the future, `nbf` (if present) must not be in the future.
+//   - `iss` must equal the configured issuer.
+//   - `aud` must contain the configured audience.
+//
+// All failures collapse to ErrInvalidToken so the middleware emits a uniform
+// 401 without leaking validation details to the caller. Detailed reasons are
+// logged.
+type JWTAuth struct {
+	cfg     JWTConfig
+	keyfunc jwt.Keyfunc
+	parser  *jwt.Parser
+}
+
+// NewJWTAuth constructs a JWTAuth. JWKS fetch happens lazily — the first
+// request triggers a fetch, subsequent requests use the cache. This means
+// the gateway can start up while Keycloak is still warming.
+//
+// If you need eager JWKS warmup at startup, call (j *JWTAuth).Warm(ctx).
+func NewJWTAuth(cfg JWTConfig) (*JWTAuth, error) {
+	if cfg.JWKSURL == "" {
+		return nil, fmt.Errorf("auth: jwt mode requires JWKSURL")
+	}
+	if cfg.Issuer == "" {
+		return nil, fmt.Errorf("auth: jwt mode requires Issuer")
+	}
+	if cfg.Audience == "" {
+		return nil, fmt.Errorf("auth: jwt mode requires Audience")
+	}
+	if cfg.SubjectClaim == "" {
+		cfg.SubjectClaim = "sub"
+	}
+	if cfg.UserClaim == "" {
+		cfg.UserClaim = "preferred_username"
+	}
+	if cfg.EmailClaim == "" {
+		cfg.EmailClaim = "email"
+	}
+
+	k, err := keyfunc.NewDefaultCtx(context.Background(), []string{cfg.JWKSURL})
+	if err != nil {
+		return nil, fmt.Errorf("auth: failed to initialise JWKS client: %w", err)
+	}
+
+	parser := jwt.NewParser(
+		jwt.WithIssuer(cfg.Issuer),
+		jwt.WithAudience(cfg.Audience),
+		jwt.WithExpirationRequired(),
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}),
+		jwt.WithLeeway(30*time.Second),
+	)
+
+	return &JWTAuth{
+		cfg:     cfg,
+		keyfunc: k.Keyfunc,
+		parser:  parser,
+	}, nil
+}
+
+// Authenticate extracts the bearer token, validates it, and projects the
+// resolved claims onto an Identity.
+func (j *JWTAuth) Authenticate(r *http.Request) (Identity, error) {
+	tokenStr, ok := bearerToken(r)
+	if !ok {
+		return Identity{}, ErrInvalidToken
+	}
+
+	claims := jwt.MapClaims{}
+	tok, err := j.parser.ParseWithClaims(tokenStr, claims, j.keyfunc)
+	if err != nil {
+		// keyfunc returns a wrapped error when the JWKS endpoint is
+		// unreachable AND the cache is cold. Surface that distinctly so
+		// the middleware can emit 503 instead of 401.
+		if isJWKSColdCacheError(err) {
+			return Identity{}, ErrJWKSUnavailable
+		}
+		return Identity{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	if !tok.Valid {
+		return Identity{}, ErrInvalidToken
+	}
+
+	subject := stringClaim(claims, j.cfg.SubjectClaim)
+	if subject == "" {
+		// A token without a usable subject is unusable downstream.
+		return Identity{}, fmt.Errorf("%w: missing %q claim", ErrInvalidToken, j.cfg.SubjectClaim)
+	}
+
+	return Identity{
+		Subject: subject,
+		User:    stringClaim(claims, j.cfg.UserClaim),
+		Email:   stringClaim(claims, j.cfg.EmailClaim),
+		Mode:    ModeJWT,
+	}, nil
+}
+
+// bearerToken extracts the token from an `Authorization: Bearer <token>`
+// header. Returns ok=false when the header is missing, malformed, or uses
+// a scheme other than Bearer.
+func bearerToken(r *http.Request) (string, bool) {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return "", false
+	}
+	const prefix = "Bearer "
+	if len(h) <= len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+	tok := strings.TrimSpace(h[len(prefix):])
+	if tok == "" {
+		return "", false
+	}
+	return tok, true
+}
+
+// stringClaim returns the named claim as a string, or "" if absent or not
+// a string.
+func stringClaim(claims jwt.MapClaims, name string) string {
+	if v, ok := claims[name].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// isJWKSColdCacheError returns true when err indicates the JWKS endpoint
+// could not be reached AND no key was available in the cache.
+//
+// keyfunc/v3 returns jwkset.ErrNewClient or wraps a network error from the
+// initial fetch when the cache has nothing to fall back on. In that case
+// the gateway is degraded — emit 503, not 401, so a client retry behind a
+// load balancer has a chance to land on a healthier replica.
+func isJWKSColdCacheError(err error) bool {
+	// keyfunc surfaces a sentinel ErrKeyfunc on signing-key lookup failure;
+	// when the cache is cold the wrapped error is the underlying network
+	// error. We can't import private sentinels, so match on the message
+	// fragment that keyfunc emits in this case.
+	msg := err.Error()
+	return strings.Contains(msg, "could not find kid") ||
+		strings.Contains(msg, "failed to refresh") ||
+		strings.Contains(msg, "no keys in JWK Set")
+}

--- a/internal/auth/jwt_keycloak_integration_test.go
+++ b/internal/auth/jwt_keycloak_integration_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+
+// Package-level integration test for JWT mode against a live Keycloak.
+//
+// Run by setting KC_INTEGRATION=1 plus the env vars below, then:
+//
+//	go test -tags integration -run TestJWTAuth_LiveKeycloak ./internal/auth/...
+//
+// The companion script `scripts/keycloak-test-setup.sh` provisions a clean
+// realm + client + user inside the keycloak-keycloak namespace and prints
+// an eval-able env block:
+//
+//	eval "$(scripts/keycloak-test-setup.sh)"
+//	go test -tags integration -run TestJWTAuth_LiveKeycloak ./internal/auth/...
+//
+// The test is skipped when KC_INTEGRATION is unset so CI without cluster
+// access stays green.
+
+package auth_test
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fips-agents/gateway-template/internal/auth"
+)
+
+func mustEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Fatalf("integration test requires env %s", key)
+	}
+	return v
+}
+
+// liveKeycloakHTTPClient skips TLS verify because the sandbox cluster uses
+// a self-signed wildcard cert. Production deployments should use the
+// system CA bundle.
+func liveKeycloakHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // sandbox-only
+		},
+	}
+}
+
+// fetchUserToken does a Resource Owner Password Credentials grant. This is
+// the simplest way to get a user-bearing access token in a test; production
+// callers use the auth-code flow.
+func fetchUserToken(t *testing.T, tokenURL, clientID, clientSecret, user, password string) string {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("username", user)
+	form.Set("password", password)
+	form.Set("scope", "openid email profile")
+
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := liveKeycloakHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body := make([]byte, 512)
+		n, _ := resp.Body.Read(body)
+		t.Fatalf("token endpoint returned %d: %s", resp.StatusCode, body[:n])
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if payload.AccessToken == "" {
+		t.Fatal("token endpoint returned empty access_token")
+	}
+	return payload.AccessToken
+}
+
+// jwtAuthForLive constructs a JWTAuth that points at the live Keycloak.
+// It also patches the default http.DefaultTransport to skip TLS verify so
+// the JWKS fetch succeeds against the sandbox cluster's self-signed cert.
+//
+// We do this with a defer-restore so the global is only mutated for the
+// duration of the test. This is gross but localised — the alternative is
+// to plumb an http.Client through JWTAuth's surface, which we can do in
+// a follow-up if real deployments need it.
+func jwtAuthForLive(t *testing.T) (auth.Authenticator, func()) {
+	t.Helper()
+	orig := http.DefaultTransport
+	http.DefaultTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // sandbox-only
+	}
+	cleanup := func() { http.DefaultTransport = orig }
+
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:  mustEnv(t, "KC_JWKS_URL"),
+			Issuer:   mustEnv(t, "KC_ISSUER"),
+			Audience: mustEnv(t, "KC_AUDIENCE"),
+		},
+	})
+	if err != nil {
+		cleanup()
+		t.Fatalf("auth.New(jwt): %v", err)
+	}
+	return a, cleanup
+}
+
+func TestJWTAuth_LiveKeycloak_HappyPath(t *testing.T) {
+	if os.Getenv("KC_INTEGRATION") == "" {
+		t.Skip("set KC_INTEGRATION=1 (and run scripts/keycloak-test-setup.sh) to enable")
+	}
+
+	a, cleanup := jwtAuthForLive(t)
+	defer cleanup()
+
+	tok := fetchUserToken(t,
+		mustEnv(t, "KC_TOKEN_URL"),
+		mustEnv(t, "KC_CLIENT_ID"),
+		mustEnv(t, "KC_CLIENT_SECRET"),
+		mustEnv(t, "KC_USERNAME"),
+		mustEnv(t, "KC_PASSWORD"),
+	)
+
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r.Header.Set("Authorization", "Bearer "+tok)
+
+	id, err := a.Authenticate(r)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if id.Subject == "" {
+		t.Errorf("expected non-empty subject, got %+v", id)
+	}
+	if id.Mode != auth.ModeJWT {
+		t.Errorf("expected mode=jwt, got %q", id.Mode)
+	}
+	wantUser := os.Getenv("KC_USERNAME")
+	if id.User != wantUser {
+		t.Errorf("expected User=%q, got %q", wantUser, id.User)
+	}
+	wantEmail := os.Getenv("KC_USER_EMAIL")
+	if id.Email != wantEmail {
+		t.Errorf("expected Email=%q, got %q", wantEmail, id.Email)
+	}
+}
+
+func TestJWTAuth_LiveKeycloak_RejectsTamperedToken(t *testing.T) {
+	if os.Getenv("KC_INTEGRATION") == "" {
+		t.Skip("set KC_INTEGRATION=1 to enable")
+	}
+
+	a, cleanup := jwtAuthForLive(t)
+	defer cleanup()
+
+	tok := fetchUserToken(t,
+		mustEnv(t, "KC_TOKEN_URL"),
+		mustEnv(t, "KC_CLIENT_ID"),
+		mustEnv(t, "KC_CLIENT_SECRET"),
+		mustEnv(t, "KC_USERNAME"),
+		mustEnv(t, "KC_PASSWORD"),
+	)
+	// Flip a byte in the signature so the JWS verification fails.
+	tampered := tok[:len(tok)-2] + "AA"
+
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r.Header.Set("Authorization", "Bearer "+tampered)
+
+	if _, err := a.Authenticate(r); err == nil {
+		t.Fatal("Authenticate accepted a tampered token")
+	}
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,385 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fips-agents/gateway-template/internal/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// jwksFixture is a minimal JWKS server backed by an RSA keypair. It tracks
+// fetch attempts so tests can assert cache behaviour, and supports forcing
+// a 503 to simulate Keycloak unavailability.
+type jwksFixture struct {
+	priv     *rsa.PrivateKey
+	kid      string
+	server   *httptest.Server
+	fetches  atomic.Int64
+	failNext atomic.Bool
+}
+
+func newJWKSFixture(t *testing.T) *jwksFixture {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	// Derive a stable kid from the public modulus.
+	hash := sha256.Sum256(priv.PublicKey.N.Bytes())
+	kid := base64.RawURLEncoding.EncodeToString(hash[:8])
+
+	f := &jwksFixture{priv: priv, kid: kid}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.fetches.Add(1)
+		if f.failNext.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		n := base64.RawURLEncoding.EncodeToString(priv.PublicKey.N.Bytes())
+		// Encode public exponent as big-endian, trim leading zero bytes.
+		eBytes := []byte{
+			byte(priv.PublicKey.E >> 16),
+			byte(priv.PublicKey.E >> 8),
+			byte(priv.PublicKey.E),
+		}
+		for len(eBytes) > 1 && eBytes[0] == 0 {
+			eBytes = eBytes[1:]
+		}
+		e := base64.RawURLEncoding.EncodeToString(eBytes)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{
+					"kty": "RSA",
+					"alg": "RS256",
+					"use": "sig",
+					"kid": f.kid,
+					"n":   n,
+					"e":   e,
+				},
+			},
+		})
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// signToken signs a token with the fixture's key. claims overrides the
+// default exp/nbf/iss/aud — pass any subset.
+func (f *jwksFixture) signToken(t *testing.T, claims jwt.MapClaims, kid string) string {
+	t.Helper()
+	if kid == "" {
+		kid = f.kid
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(f.priv)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return signed
+}
+
+// signWithOtherKey signs with a fresh key the JWKS does not advertise.
+func (f *jwksFixture) signWithOtherKey(t *testing.T, claims jwt.MapClaims, kid string) string {
+	t.Helper()
+	other, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	// Discard the public key; we only need the signature to fail validation.
+	_ = x509.MarshalPKCS1PublicKey(&other.PublicKey)
+	signed, err := tok.SignedString(other)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return signed
+}
+
+// defaultClaims returns a baseline set of valid claims.
+func defaultClaims(iss, aud string) jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":                iss,
+		"aud":                aud,
+		"sub":                "user-123",
+		"preferred_username": "alice",
+		"email":              "alice@example.com",
+		"iat":                now.Unix(),
+		"nbf":                now.Add(-1 * time.Minute).Unix(),
+		"exp":                now.Add(5 * time.Minute).Unix(),
+	}
+}
+
+func newJWTAuth(t *testing.T, f *jwksFixture, iss, aud string) auth.Authenticator {
+	t.Helper()
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:  f.server.URL,
+			Issuer:   iss,
+			Audience: aud,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New(jwt): %v", err)
+	}
+	return a
+}
+
+func reqWithBearer(token string) *http.Request {
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+const (
+	testIssuer   = "https://kc.example/realms/test"
+	testAudience = "gateway-template"
+)
+
+func TestJWTAuth_HappyPath(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	id, err := a.Authenticate(reqWithBearer(tok))
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	want := auth.Identity{
+		Subject: "user-123",
+		User:    "alice",
+		Email:   "alice@example.com",
+		Mode:    auth.ModeJWT,
+	}
+	if id != want {
+		t.Errorf("identity: got %+v, want %+v", id, want)
+	}
+}
+
+func TestJWTAuth_RejectsExpired(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	c := defaultClaims(testIssuer, testAudience)
+	c["exp"] = time.Now().Add(-2 * time.Minute).Unix()
+	tok := f.signToken(t, c, "")
+
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsNotYetValid(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	c := defaultClaims(testIssuer, testAudience)
+	// Push nbf well past the parser's 30s leeway.
+	c["nbf"] = time.Now().Add(5 * time.Minute).Unix()
+	tok := f.signToken(t, c, "")
+
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsWrongIssuer(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := f.signToken(t, defaultClaims("https://other.example/realms/x", testAudience), "")
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsWrongAudience(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, "some-other-service"), "")
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsBadSignature(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	// Sign with a key the JWKS does not advertise, but advertise our kid
+	// so the validator fetches the real public key and rejects the signature.
+	tok := f.signWithOtherKey(t, defaultClaims(testIssuer, testAudience), f.kid)
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsUnknownKid(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "kid-not-in-jwks")
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsMissingAuthorization(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	_, err := a.Authenticate(reqWithBearer(""))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsMalformedAuthorization(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	// Wrong scheme.
+	r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+
+	_, err := a.Authenticate(r)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_RejectsMissingSubjectClaim(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	c := defaultClaims(testIssuer, testAudience)
+	delete(c, "sub")
+	tok := f.signToken(t, c, "")
+
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestJWTAuth_CustomClaimMapping(t *testing.T) {
+	f := newJWKSFixture(t)
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:      f.server.URL,
+			Issuer:       testIssuer,
+			Audience:     testAudience,
+			SubjectClaim: "uid",
+			UserClaim:    "username",
+			EmailClaim:   "mail",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	c := defaultClaims(testIssuer, testAudience)
+	c["uid"] = "u-7"
+	c["username"] = "bob"
+	c["mail"] = "bob@x.test"
+
+	tok := f.signToken(t, c, "")
+	id, err := a.Authenticate(reqWithBearer(tok))
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	want := auth.Identity{
+		Subject: "u-7",
+		User:    "bob",
+		Email:   "bob@x.test",
+		Mode:    auth.ModeJWT,
+	}
+	if id != want {
+		t.Errorf("identity: got %+v, want %+v", id, want)
+	}
+}
+
+func TestJWTAuth_WarmCacheSurvivesJWKSOutage(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	// First call populates the cache.
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	if _, err := a.Authenticate(reqWithBearer(tok)); err != nil {
+		t.Fatalf("warmup Authenticate: %v", err)
+	}
+
+	// Now break the JWKS endpoint and verify another valid token still works.
+	f.failNext.Store(true)
+
+	tok2 := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	if _, err := a.Authenticate(reqWithBearer(tok2)); err != nil {
+		t.Fatalf("post-outage Authenticate: %v (cache should have served us)", err)
+	}
+}
+
+func TestJWTAuth_RejectsNoneAlg(t *testing.T) {
+	// Defence against the classic "alg=none" downgrade. The parser is
+	// configured with WithValidMethods so unsigned tokens must fail.
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, defaultClaims(testIssuer, testAudience))
+	tok.Header["kid"] = f.kid
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	_, err = a.Authenticate(reqWithBearer(signed))
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken for alg=none, got %v", err)
+	}
+}
+
+// Sanity check that the fixture itself round-trips, so a real failure in
+// the validation path can be told apart from a fixture bug.
+func TestJWKSFixture_RoundTrip(t *testing.T) {
+	f := newJWKSFixture(t)
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	if tok == "" {
+		t.Fatal("signed token should not be empty")
+	}
+	resp, err := http.Get(f.server.URL)
+	if err != nil {
+		t.Fatalf("GET JWKS: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("JWKS status: %d", resp.StatusCode)
+	}
+	if got := f.fetches.Load(); got < 1 {
+		t.Errorf("expected at least 1 JWKS fetch, got %d", got)
+	}
+	// Silence unused-import warnings for fmt when test fails are commented out.
+	_ = fmt.Sprintf
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 )
@@ -41,6 +42,18 @@ func Middleware(a Authenticator) func(http.Handler) http.Handler {
 
 			id, err := a.Authenticate(r)
 			if err != nil {
+				// ErrInvalidToken → 401: caller's bearer token is bad.
+				// Everything else (ErrMissingProxyHeaders, ErrJWKSUnavailable,
+				// arbitrary errors) → 503: deployment is degraded.
+				if errors.Is(err, ErrInvalidToken) {
+					slog.Info("auth: rejecting invalid bearer token",
+						"error", err,
+						"path", r.URL.Path,
+						"method", r.Method,
+					)
+					http.Error(w, `{"error":"invalid bearer token"}`, http.StatusUnauthorized)
+					return
+				}
 				slog.Error("auth: identity resolution failed",
 					"error", err,
 					"path", r.URL.Path,

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -152,9 +152,9 @@ func TestMiddleware_HealthProbesStillStripSpoofedHeaders(t *testing.T) {
 	}
 }
 
-// TestMiddleware_StubError ensures that any non-nil error from the
-// authenticator (not just ErrMissingProxyHeaders) causes a 503.
-func TestMiddleware_AnyAuthErrorReturns503(t *testing.T) {
+// TestMiddleware_GenericErrorReturns503 ensures that any non-sentinel
+// error from the authenticator (deployment-level failure) causes a 503.
+func TestMiddleware_GenericErrorReturns503(t *testing.T) {
 	called := false
 	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
 
@@ -169,6 +169,40 @@ func TestMiddleware_AnyAuthErrorReturns503(t *testing.T) {
 	}
 	if called {
 		t.Error("downstream handler ran despite auth error")
+	}
+}
+
+// TestMiddleware_InvalidTokenReturns401 ensures ErrInvalidToken is
+// distinguished from deployment-level failures and produces 401.
+func TestMiddleware_InvalidTokenReturns401(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+
+	stub := stubAuth{err: auth.ErrInvalidToken}
+	h := auth.Middleware(stub)(next)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+	if called {
+		t.Error("downstream handler ran despite auth error")
+	}
+}
+
+// TestMiddleware_WrappedInvalidTokenReturns401 ensures errors.Is unwrapping
+// works so jwt.go can wrap ErrInvalidToken with details.
+func TestMiddleware_WrappedInvalidTokenReturns401(t *testing.T) {
+	stub := stubAuth{err: errors.Join(auth.ErrInvalidToken, errors.New("token expired"))}
+	h := auth.Middleware(stub)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,8 @@ type Config struct {
 	AgentVersion string
 	LogRequests  bool
 
-	// AuthMode selects the inbound auth strategy: "anonymous" (default)
-	// or "proxy". See internal/auth.
+	// AuthMode selects the inbound auth strategy: "anonymous" (default),
+	// "proxy", or "jwt". See internal/auth.
 	AuthMode string
 	// AuthProxyUserHeader is the upstream-projected username header
 	// consulted in proxy mode. Defaults to "X-Forwarded-User"
@@ -24,6 +24,15 @@ type Config struct {
 	// AuthProxyEmailHeader is the upstream-projected email header. Empty
 	// means the deployment does not surface email.
 	AuthProxyEmailHeader string
+
+	// JWT mode: in-process bearer-token validation against a JWKS endpoint.
+	// All AuthJWT* fields are consulted only when AuthMode == "jwt".
+	AuthJWTJWKSURL      string
+	AuthJWTIssuer       string
+	AuthJWTAudience     string
+	AuthJWTSubjectClaim string
+	AuthJWTUserClaim    string
+	AuthJWTEmailClaim   string
 }
 
 // Load reads configuration from environment variables and validates required fields.
@@ -37,10 +46,27 @@ func Load() (*Config, error) {
 		AuthMode:             envOrDefault("GATEWAY_AUTH_MODE", "anonymous"),
 		AuthProxyUserHeader:  envOrDefault("GATEWAY_AUTH_PROXY_USER_HEADER", "X-Forwarded-User"),
 		AuthProxyEmailHeader: envOrDefault("GATEWAY_AUTH_PROXY_EMAIL_HEADER", "X-Forwarded-Email"),
+		AuthJWTJWKSURL:       os.Getenv("GATEWAY_AUTH_JWT_JWKS_URL"),
+		AuthJWTIssuer:        os.Getenv("GATEWAY_AUTH_JWT_ISSUER"),
+		AuthJWTAudience:      os.Getenv("GATEWAY_AUTH_JWT_AUDIENCE"),
+		AuthJWTSubjectClaim:  envOrDefault("GATEWAY_AUTH_JWT_SUBJECT_CLAIM", "sub"),
+		AuthJWTUserClaim:     envOrDefault("GATEWAY_AUTH_JWT_USER_CLAIM", "preferred_username"),
+		AuthJWTEmailClaim:    envOrDefault("GATEWAY_AUTH_JWT_EMAIL_CLAIM", "email"),
 	}
 
 	if cfg.BackendURL == "" {
 		return nil, fmt.Errorf("BACKEND_URL environment variable is required")
+	}
+	if cfg.AuthMode == "jwt" {
+		if cfg.AuthJWTJWKSURL == "" {
+			return nil, fmt.Errorf("GATEWAY_AUTH_JWT_JWKS_URL is required when GATEWAY_AUTH_MODE=jwt")
+		}
+		if cfg.AuthJWTIssuer == "" {
+			return nil, fmt.Errorf("GATEWAY_AUTH_JWT_ISSUER is required when GATEWAY_AUTH_MODE=jwt")
+		}
+		if cfg.AuthJWTAudience == "" {
+			return nil, fmt.Errorf("GATEWAY_AUTH_JWT_AUDIENCE is required when GATEWAY_AUTH_MODE=jwt")
+		}
 	}
 
 	return cfg, nil

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # gateway-template
 
-> OpenAI-compatible HTTP reverse proxy for AI agent backends, built with the Go standard library only. Accepts `/v1/chat/completions` requests (sync and SSE streaming), proxies them to a configurable backend, and handles SSE lifecycle management.
+> OpenAI-compatible HTTP reverse proxy for AI agent backends. Built primarily on the Go standard library; the only third-party deps are stdlib-crypto-only JWT/JWKS libraries used by the optional `jwt` auth mode. Accepts `/v1/chat/completions` requests (sync and SSE streaming), proxies them to a configurable backend, and handles SSE lifecycle management.
 
 This is a template repository. The sentinel string `gateway-template` is replaced with the actual project name during scaffolding via `fips-agents create gateway <name>`.
 
@@ -8,13 +8,14 @@ This is a template repository. The sentinel string `gateway-template` is replace
 
 - [README](https://raw.githubusercontent.com/fips-agents/gateway-template/main/README.md): Project overview, configuration variables, endpoints, and deployment instructions
 - [Server entrypoint](https://raw.githubusercontent.com/fips-agents/gateway-template/main/cmd/server/main.go): HTTP mux wiring, graceful shutdown, route registration
-- [Config](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/config/config.go): Environment variable parsing (BACKEND_URL, PORT, AGENT_NAME, AGENT_VERSION, LOG_REQUESTS, GATEWAY_AUTH_MODE, GATEWAY_AUTH_PROXY_USER_HEADER, GATEWAY_AUTH_PROXY_EMAIL_HEADER)
+- [Config](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/config/config.go): Environment variable parsing (BACKEND_URL, PORT, AGENT_NAME, AGENT_VERSION, LOG_REQUESTS, GATEWAY_AUTH_MODE, GATEWAY_AUTH_PROXY_*, GATEWAY_AUTH_JWT_*)
 
 ## Handlers
 
 - [Chat completions](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/chat.go): POST /v1/chat/completions — sync and SSE streaming proxy
 - [Feedback](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/feedback.go): POST/GET /v1/feedback, PATCH /v1/feedback/{id}, GET /v1/feedback/stats — pass-through; forwards canonical X-Auth-* headers
-- [Auth](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/auth/auth.go): Inbound auth strategies (anonymous, proxy) and middleware that projects identity onto canonical X-Auth-Subject / X-Auth-User / X-Auth-Email / X-Auth-Mode headers
+- [Auth strategies](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/auth/auth.go): Inbound auth modes (anonymous, proxy, jwt) and middleware that projects identity onto canonical X-Auth-Subject / X-Auth-User / X-Auth-Email / X-Auth-Mode headers
+- [JWT mode](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/auth/jwt.go): In-process JWKS validation of `Authorization: Bearer <token>`. Enforces signature, iss, aud, exp, nbf. Maps invalid tokens → 401, JWKS-cold-cache failures → 503. Stdlib crypto only (FIPS-compatible).
 - [Health](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/health.go): GET /healthz and /readyz endpoints
 - [Agent card](https://raw.githubusercontent.com/fips-agents/gateway-template/main/internal/handler/wellknown.go): GET /.well-known/agent.json
 

--- a/scripts/keycloak-test-setup.sh
+++ b/scripts/keycloak-test-setup.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Bootstrap a Keycloak realm, client, and user for the gateway-template
+# JWT-mode integration test.
+#
+# Idempotent: re-running is safe. The realm is named gateway-template-test
+# and is reset on each run so the test gets a clean baseline.
+#
+# Prereqs:
+#   - oc / kubectl access to the cluster running the keycloak operator
+#   - kcadm.sh available inside the keycloak pod (it is, by default)
+#
+# Outputs an `eval`-able snippet of env vars on stdout so the integration
+# test can pick them up:
+#
+#   eval "$(scripts/keycloak-test-setup.sh)"
+#   go test -tags integration ./internal/auth/...
+
+set -euo pipefail
+
+CTX="${KC_CONTEXT:-mcp-rhoai}"
+NS="${KC_NAMESPACE:-keycloak}"
+POD="${KC_POD:-keycloak-0}"
+REALM="${KC_TEST_REALM:-gateway-template-test}"
+CLIENT_ID="${KC_TEST_CLIENT_ID:-gateway-template}"
+USER_NAME="${KC_TEST_USER:-alice}"
+USER_PASS="${KC_TEST_USER_PASSWORD:-alicepw}"
+USER_EMAIL="${KC_TEST_USER_EMAIL:-alice@example.test}"
+
+ROUTE_HOST=$(oc --context="$CTX" -n "$NS" get route keycloak -o jsonpath='{.spec.host}')
+ISSUER="https://${ROUTE_HOST}/realms/${REALM}"
+JWKS_URL="${ISSUER}/protocol/openid-connect/certs"
+TOKEN_URL="${ISSUER}/protocol/openid-connect/token"
+
+ADMIN_USER=$(oc --context="$CTX" -n "$NS" get secret keycloak-initial-admin -o jsonpath='{.data.username}' | base64 -d)
+ADMIN_PASS=$(oc --context="$CTX" -n "$NS" get secret keycloak-initial-admin -o jsonpath='{.data.password}' | base64 -d)
+
+# Run kcadm commands inside the keycloak pod. Connecting via localhost on
+# the pod skips TLS issues with the OpenShift route.
+KCADM_CONFIG="/tmp/kcadm-${REALM}.config"
+# Quiet wrapper for fire-and-forget kcadm calls.
+kcq() {
+  oc --context="$CTX" -n "$NS" exec "$POD" -- /opt/keycloak/bin/kcadm.sh "$@" --config "$KCADM_CONFIG" >&2
+}
+# Loud wrapper for calls whose stdout we capture (uses kcadm's -i flag).
+kc() {
+  oc --context="$CTX" -n "$NS" exec "$POD" -- /opt/keycloak/bin/kcadm.sh "$@" --config "$KCADM_CONFIG"
+}
+
+# Authenticate to the master realm.
+kcq config credentials \
+  --server http://localhost:8080 \
+  --realm master \
+  --user "$ADMIN_USER" \
+  --password "$ADMIN_PASS"
+
+# Wipe the test realm if it exists, then recreate it.
+if kc get "realms/${REALM}" >/dev/null 2>&1; then
+  kcq delete "realms/${REALM}"
+fi
+
+kcq create realms -s "realm=${REALM}" -s enabled=true
+
+# Create a confidential client with direct-grant + client-credentials enabled.
+CLIENT_UUID=$(kc create clients -r "$REALM" \
+  -s "clientId=${CLIENT_ID}" \
+  -s "secret=test-secret" \
+  -s "publicClient=false" \
+  -s "directAccessGrantsEnabled=true" \
+  -s "serviceAccountsEnabled=true" \
+  -s 'redirectUris=["*"]' \
+  -i 2>/dev/null | tr -d '\r\n')
+
+# Create the test user with a password, email, and first/last name.
+# Keycloak's user-profile validation rejects the password grant with
+# "Account is not fully set up" if any "required" profile field is missing
+# at login time, even when realm `requiredActions` are otherwise clear.
+# Providing firstName/lastName up-front sidesteps that resolution path.
+USER_UUID=$(kc create users -r "$REALM" \
+  -s "username=${USER_NAME}" \
+  -s "email=${USER_EMAIL}" \
+  -s "firstName=Test" \
+  -s "lastName=User" \
+  -s "emailVerified=true" \
+  -s "enabled=true" \
+  -s 'requiredActions=[]' \
+  -i 2>/dev/null | tr -d '\r\n')
+
+kcq set-password -r "$REALM" \
+  --userid "$USER_UUID" \
+  --new-password "$USER_PASS"
+
+# Clear required actions defensively, in case the realm has defaults that
+# attached on user creation.
+kcq update "users/${USER_UUID}" -r "$REALM" -s 'requiredActions=[]'
+
+# By default Keycloak does not include the client_id in the `aud` claim
+# unless the client is in the audience or there is an audience-mapper.
+# Add an audience mapper so tokens get aud=${CLIENT_ID}.
+kcq create "clients/${CLIENT_UUID}/protocol-mappers/models" -r "$REALM" \
+  -s "name=aud-${CLIENT_ID}" \
+  -s "protocol=openid-connect" \
+  -s "protocolMapper=oidc-audience-mapper" \
+  -s 'config."included.client.audience"='"${CLIENT_ID}" \
+  -s 'config."access.token.claim"=true' \
+  -s 'config."id.token.claim"=false'
+
+cat <<EOF
+export KC_INTEGRATION=1
+export KC_ISSUER="${ISSUER}"
+export KC_JWKS_URL="${JWKS_URL}"
+export KC_TOKEN_URL="${TOKEN_URL}"
+export KC_AUDIENCE="${CLIENT_ID}"
+export KC_CLIENT_ID="${CLIENT_ID}"
+export KC_CLIENT_SECRET="test-secret"
+export KC_USERNAME="${USER_NAME}"
+export KC_PASSWORD="${USER_PASS}"
+export KC_USER_EMAIL="${USER_EMAIL}"
+EOF


### PR DESCRIPTION
## Summary

- Adds `GATEWAY_AUTH_MODE=jwt` as a third inbound auth strategy alongside `anonymous` and `proxy`. The gateway validates `Authorization: Bearer <token>` against a JWKS endpoint (cached by `kid`), enforces `iss`/`aud`/`exp`/`nbf`, and projects the configured claims onto the canonical `X-Auth-*` headers.
- Distinguishes 401 (invalid token) from 503 (JWKS unreachable + cache cold). Rejects `alg=none`, HS*, and any other non-asymmetric algorithm by parser whitelist.
- FIPS-compatible: `golang-jwt/jwt/v5` and `MicahParks/keyfunc/v3` use Go stdlib crypto only, so the binary routes through the FIPS module under `GOFIPS140=on` / `GOEXPERIMENT=boringcrypto`.

Refs `#23`. RFC 8693 token exchange to MCP/tools is the remaining v2 work and will land in a follow-up PR.

## Test plan

- [x] `go test ./...` — 13 new unit tests with a stub-JWKS RSA-keypair fixture covering happy path, expired, nbf-future, wrong issuer/audience, bad signature, unknown kid, missing/malformed `Authorization`, alg=none downgrade, custom claim mapping, warm-cache survives JWKS outage
- [x] `go test -tags integration` — 2 build-tagged tests against a live RHBK instance in the `mcp-rhoai` cluster (auto-skip when `KC_INTEGRATION` unset)
- [x] `go vet ./...`
- [x] `helm lint chart/` and `helm template` confirms env vars render correctly + required-field guards fire when `auth.mode=jwt` without `auth.jwt.jwksUrl`/`issuer`/`audience`
- [x] **End-to-end smoke** against a freshly scaffolded agent (`fips-agents create agent jwt-smoke-agent`) deployed in a fresh OpenShift namespace (`gw-jwt-smoke`) with both images built via OpenShift BuildConfig:
  - 9/9 auth assertions pass (health bypass, all unauthed paths → 401, malformed `Authorization` → 401, valid Keycloak-issued token → 200, tampered signature → 401)
  - 3/3 spoof-resistance checks pass (forged inbound `X-Auth-*` headers ignored both with and without a valid token; gateway always projects identity from the validated JWT)

## Operational note

`MicahParks/keyfunc/v3` defaults a refresh rate limiter that throttles JWKS re-fetch on unknown-`kid`. Surfaces as `failed to wait for JWK Set refresh rate limiter: rate: Wait(n=1) would exceed context deadline` during real-world key rotation. Worth tuning `RefreshRateLimit` in a follow-up; not a blocker for typical Keycloak rotation cadences.