### PR TITLE
chart: Bump to 0.3.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 description: Go HTTP gateway for AI agents


### PR DESCRIPTION
Reflects the addition of jwt auth mode (#25), a new public surface for the chart (`auth.jwt.*` values). Minor bump per semver.