### PR TITLE
auth: Add RFC 8693 token exchange to jwt mode (auth v2 part 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ make image-build
 
 ## Architecture
 
-This is a thin reverse proxy -- minimal external dependencies. The core proxy and auth middleware use the Go standard library only; the `jwt` auth mode adds two stdlib-crypto-only third-party deps (`github.com/golang-jwt/jwt/v5`, `github.com/MicahParks/keyfunc/v3`) to validate inbound bearer tokens against a JWKS endpoint. Both libraries route through Go's FIPS-certified crypto module when the binary is built with FIPS enabled.
+This is a thin reverse proxy -- minimal external dependencies. The core proxy and auth middleware use the Go standard library only; the `jwt` auth mode adds two stdlib-crypto-only third-party deps (`github.com/golang-jwt/jwt/v5`, `github.com/MicahParks/keyfunc/v3`) to validate inbound bearer tokens against a JWKS endpoint. The optional RFC 8693 token-exchange path on top of `jwt` mode adds no new third-party deps — it speaks plain `application/x-www-form-urlencoded` to the IdP's token endpoint via stdlib `net/http`. Both crypto libraries route through Go's FIPS-certified crypto module when the binary is built with FIPS enabled.
 
 ```
 Client --> Gateway (:8080) --> Backend Agent
@@ -45,7 +45,7 @@ Key packages:
 - `internal/config/` -- environment variable parsing
 - `internal/handler/` -- HTTP handlers for each route
 - `internal/middleware/` -- request logging (structured, skips health probes)
-- `internal/auth/` -- inbound auth strategies (`anonymous`, `proxy`, `jwt`) + middleware that strips spoofed `X-Auth-*` headers and projects canonical identity onto the request. `jwt` mode validates `Authorization: Bearer <token>` against a configured JWKS endpoint (cached by `kid`), enforces `iss`/`aud`/`exp`/`nbf`, and maps invalid tokens → 401 vs. JWKS-cold-cache failures → 503
+- `internal/auth/` -- inbound auth strategies (`anonymous`, `proxy`, `jwt`) + middleware that strips spoofed `X-Auth-*` headers and projects canonical identity onto the request. `jwt` mode validates `Authorization: Bearer <token>` against a configured JWKS endpoint (cached by `kid`), enforces `iss`/`aud`/`exp`/`nbf`, and maps invalid tokens → 401 vs. JWKS-cold-cache failures → 503. Optional RFC 8693 token exchange (`exchange.go`) swaps the inbound user JWT for a downstream-audienced token before the handler runs; `Identity.BearerToken` carries the swapped value, the middleware projects it as `Authorization: Bearer <token>` on the request (or strips Authorization entirely when no swap is configured), and handlers forward it to the backend
 - `internal/proxy/` -- SSE relay logic
 
 ## Configuration
@@ -66,10 +66,17 @@ Key packages:
 | `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim → `X-Auth-Subject` |
 | `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim → `X-Auth-User` |
 | `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim → `X-Auth-Email` |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL` | exchange | -- | (`jwt` mode) RFC 8693 token endpoint; setting all four required exchange vars enables the swap |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID` | exchange | -- | (`jwt` mode) gateway service-account client ID |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) gateway service-account client secret |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE` | exchange | -- | (`jwt` mode) downstream audience the swapped token targets |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE` | No | -- | (`jwt` mode) optional space-separated scope set requested on the swap |
 
 ## Auth contract
 
-The gateway emits canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers to the backend on every `/v1/*` request. Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's AuthBridge JWT claim shape, so an AuthBridge token and a fipsagents-issued token resolve onto the same canonical contract. `proxy` mode fails closed with 503 when the upstream user header is missing. `jwt` mode validates `Authorization: Bearer <token>` against a JWKS endpoint, returning 401 on bad/expired/wrong-issuer/wrong-audience tokens and 503 only when the JWKS endpoint is unreachable AND the cache is cold. Token-exchange (RFC 8693) for downstream MCP/tool calls is deferred to a follow-up.
+The gateway emits canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers to the backend on every `/v1/*` request. Inbound copies are stripped before the strategy runs so clients cannot spoof identity. Header names match Kagenti's AuthBridge JWT claim shape, so an AuthBridge token and a fipsagents-issued token resolve onto the same canonical contract. `proxy` mode fails closed with 503 when the upstream user header is missing. `jwt` mode validates `Authorization: Bearer <token>` against a JWKS endpoint, returning 401 on bad/expired/wrong-issuer/wrong-audience tokens and 503 only when the JWKS endpoint is unreachable AND the cache is cold.
+
+`Authorization` itself is part of the contract: by default the middleware strips inbound Authorization before the handler runs (so the gateway never forwards a raw user JWT). When the four `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_*` env vars are set together, the gateway performs an RFC 8693 swap of the inbound token (subject_token) for a downstream-audienced token (the `audience` form parameter), caches it for `min(expires_in − 30s, 5min)` keyed by `sha256(inbound-token)`, and forwards it as `Authorization: Bearer <swapped>` to the backend. Exchange failures fail closed with 503. Partial token-exchange config (some required vars set, others not) is rejected at startup so a typo cannot silently disable the swap.
 
 ### Live integration test
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ curl http://localhost:8080/healthz
 | `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim to project onto `X-Auth-Subject` |
 | `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim to project onto `X-Auth-User` |
 | `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim to project onto `X-Auth-Email` |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL` | exchange | -- | (`jwt` mode, optional) RFC 8693 token endpoint. Setting this together with the next three enables token exchange. |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID` | exchange | -- | (`jwt` mode) confidential client representing the gateway's service account on the exchange request |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) client secret for the exchange request |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE` | exchange | -- | (`jwt` mode) downstream audience the swapped token is issued for |
+| `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE` | No | -- | (`jwt` mode) optional space-separated scope set requested on the swap |
 
 ## Authentication
 
@@ -52,6 +57,20 @@ Inbound copies of these headers are stripped before the strategy runs, so a clie
 - `anonymous` *(default)* — no validation. `X-Auth-Subject` is set to `anonymous`. Use for local dev, smoke tests, or any deployment that does not need user attribution.
 - `proxy` — trust an upstream OAuth proxy (e.g. OpenShift `oauth-proxy` sidecar) or service-mesh `outputClaimToHeaders` filter. The gateway reads `X-Forwarded-User` / `X-Forwarded-Email` (header names configurable) and projects them onto the canonical headers. **The gateway pod must be unreachable except via that proxy** — otherwise a client can spoof the upstream headers. If the user header is missing, the gateway returns 503 (fail closed).
 - `jwt` — in-process bearer-token validation against a JWKS endpoint. The gateway reads `Authorization: Bearer <token>`, validates the signature against keys fetched from `GATEWAY_AUTH_JWT_JWKS_URL` (cached by `kid`), enforces `iss`, `aud`, `exp`, `nbf`, and projects the configured claims onto the canonical headers. Returns 401 on invalid/expired/wrong-issuer/wrong-audience tokens, 503 if the JWKS endpoint is unreachable AND the cache is cold. Use this when there is no OAuth proxy in front of the gateway (self-contained deployments, or anywhere clients can present tokens directly). Only RSA / ECDSA / RSA-PSS signatures are accepted; HMAC and `alg=none` are rejected by construction.
+
+### Token exchange (`jwt` mode only)
+
+By default the gateway forwards canonical `X-Auth-*` headers to the backend but does **not** forward `Authorization` — the backend has to trust the gateway's header projection. That is fine when the gateway and backend share a trust boundary (same namespace, NetworkPolicy locked down). It is not fine when the call crosses a trust boundary (multi-agent chains, per-user-MCP scopes), where the downstream needs a *signed* assertion of who is calling.
+
+Set the four `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_*` env vars together to opt in. The gateway will then, after validating the inbound JWT:
+
+1. Call `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693) using the configured confidential-client credentials, requesting an audience-narrowed swap of the inbound token.
+2. Cache the swapped token in-process (TTL = `min(token-expiry − 30s, 5min)`) keyed by `sha256(inbound-token)`.
+3. Forward the swap as `Authorization: Bearer <swapped>` to the backend, alongside the unchanged `X-Auth-*` headers.
+
+The downstream service validates the swapped token against the same JWKS, sees the `aud` it expects, and gets a cryptographic assertion of who is calling. Exchange failures fail closed with 503 — the gateway never silently downgrades to forwarding without the swap. The raw inbound user JWT is **never** forwarded downstream; if exchange is disabled, `Authorization` is stripped entirely.
+
+Partial configuration (some of the four required vars set, others not) is rejected at startup. Either configure all four or none.
 
 **Choosing a mode:**
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 description: Go HTTP gateway for AI agents

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -18,4 +18,12 @@ data:
   GATEWAY_AUTH_JWT_SUBJECT_CLAIM: {{ .Values.auth.jwt.subjectClaim | default "sub" | quote }}
   GATEWAY_AUTH_JWT_USER_CLAIM: {{ .Values.auth.jwt.userClaim | default "preferred_username" | quote }}
   GATEWAY_AUTH_JWT_EMAIL_CLAIM: {{ .Values.auth.jwt.emailClaim | default "email" | quote }}
+  {{- if .Values.auth.jwt.exchange.enabled }}
+  GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL: {{ required "auth.jwt.exchange.tokenUrl is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.tokenUrl | quote }}
+  GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID: {{ required "auth.jwt.exchange.clientId is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.clientId | quote }}
+  GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE: {{ required "auth.jwt.exchange.audience is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.audience | quote }}
+  {{- with .Values.auth.jwt.exchange.scope }}
+  GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE: {{ . | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -25,6 +25,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "gateway-template.fullname" . }}
+          {{- if and (eq .Values.auth.mode "jwt") .Values.auth.jwt.exchange.enabled }}
+          env:
+            - name: GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "auth.jwt.exchange.clientSecretRef.name is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.clientSecretRef.name }}
+                  key: {{ .Values.auth.jwt.exchange.clientSecretRef.key | default "client-secret" }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,6 +51,37 @@ auth:
     userClaim: preferred_username
     # Claim name to project onto X-Auth-Email. Default: email.
     emailClaim: email
+    # RFC 8693 token exchange (auth v2 part 2). When enabled, the gateway
+    # swaps the inbound user JWT for a downstream-audienced token before
+    # forwarding to the backend. The downstream MCP server / agent
+    # validates the swapped token against the same JWKS, getting a
+    # signed assertion of who is calling rather than a header it has to
+    # trust.
+    #
+    # Leave disabled if the gateway and backend share a trust boundary
+    # (e.g. same OpenShift namespace with NetworkPolicies) — the canonical
+    # X-Auth-* headers are sufficient there.
+    exchange:
+      enabled: false
+      # RFC 8693 token endpoint. Same Keycloak token endpoint that
+      # issues the inbound user tokens.
+      # Example: https://keycloak.example/realms/myrealm/protocol/openid-connect/token
+      tokenUrl: ""
+      # Confidential client representing the gateway's service account.
+      # Used as the `client_id` form parameter on the exchange request.
+      clientId: ""
+      # Reference to an existing Kubernetes Secret holding the client
+      # secret. Using a secretKeyRef keeps the secret out of values.yaml.
+      clientSecretRef:
+        name: ""
+        key: client-secret
+      # The downstream-resource client whose ID becomes the swapped
+      # token's `aud`. The downstream service must validate against
+      # this audience.
+      audience: ""
+      # Optional space-separated scope set requested on the swap. Empty
+      # means no scope narrowing.
+      scope: ""
 
 service:
   port: 8080

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	var exchanger *auth.TokenExchanger
+	if cfg.JWTExchangeEnabled() {
+		exchanger, err = auth.NewTokenExchanger(auth.TokenExchangeConfig{
+			TokenURL:     cfg.AuthJWTExchangeURL,
+			ClientID:     cfg.AuthJWTExchangeClientID,
+			ClientSecret: cfg.AuthJWTExchangeClientSecret,
+			Audience:     cfg.AuthJWTExchangeAudience,
+			Scope:        cfg.AuthJWTExchangeScope,
+		})
+		if err != nil {
+			slog.Error("token exchange configuration error", "error", err)
+			os.Exit(1)
+		}
+	}
+
 	authenticator, err := auth.New(cfg.AuthMode, auth.Options{
 		ProxyUserHeader:  cfg.AuthProxyUserHeader,
 		ProxyEmailHeader: cfg.AuthProxyEmailHeader,
@@ -37,6 +52,7 @@ func main() {
 			UserClaim:    cfg.AuthJWTUserClaim,
 			EmailClaim:   cfg.AuthJWTEmailClaim,
 		},
+		JWTExchanger: exchanger,
 	})
 	if err != nil {
 		slog.Error("auth configuration error", "error", err)
@@ -107,6 +123,7 @@ func main() {
 			"agent", cfg.AgentName,
 			"version", cfg.AgentVersion,
 			"auth_mode", cfg.AuthMode,
+			"jwt_token_exchange", exchanger != nil,
 		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,6 +49,12 @@ type Identity struct {
 	User    string
 	Email   string
 	Mode    string
+	// BearerToken is the value the middleware will project as
+	// `Authorization: Bearer <token>` to the backend. Empty means the
+	// middleware strips Authorization from the inbound request — the gateway
+	// only forwards a bearer token it has cryptographically derived (e.g.
+	// via RFC 8693 token exchange in jwt mode).
+	BearerToken string
 }
 
 // ErrMissingProxyHeaders signals that proxy mode was configured but the
@@ -72,6 +78,14 @@ type Options struct {
 
 	// JWT is consulted only in jwt mode.
 	JWT JWTConfig
+	// JWTExchanger is consulted only in jwt mode. When non-nil the gateway
+	// performs an RFC 8693 token exchange after validating the inbound
+	// token, projecting the swapped token onto Identity.BearerToken so the
+	// middleware can forward a downstream-audienced bearer instead of the
+	// raw user JWT. Optional — jwt mode without an exchanger validates and
+	// emits canonical X-Auth-* headers but forwards no Authorization
+	// downstream.
+	JWTExchanger *TokenExchanger
 }
 
 // New returns the authenticator for the given mode.
@@ -88,7 +102,7 @@ func New(mode string, opts Options) (Authenticator, error) {
 			EmailHeader: opts.ProxyEmailHeader,
 		}, nil
 	case ModeJWT:
-		return NewJWTAuth(opts.JWT)
+		return NewJWTAuth(opts.JWT, opts.JWTExchanger)
 	default:
 		return nil, fmt.Errorf("auth: unknown mode %q (want %q, %q, or %q)", mode, ModeAnonymous, ModeProxy, ModeJWT)
 	}

--- a/internal/auth/exchange.go
+++ b/internal/auth/exchange.go
@@ -1,0 +1,193 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RFC 8693 grant and token-type identifiers.
+const (
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	tokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"
+)
+
+// ErrExchangeFailed signals that a token exchange call to the authorization
+// server did not yield a usable swapped token. The middleware maps it to 503:
+// a configured exchange that does not succeed means the gateway cannot vouch
+// for the downstream call, so we fail closed rather than forward an
+// unverifiable identity.
+var ErrExchangeFailed = errors.New("auth: token exchange failed")
+
+// TokenExchangeConfig is the parsed configuration for RFC 8693 token
+// exchange. All fields except Scope, HTTPClient, CacheTTLCap, and Now are
+// required.
+type TokenExchangeConfig struct {
+	// TokenURL is the authorization server's RFC 8693 token endpoint.
+	TokenURL string
+	// ClientID and ClientSecret authenticate the gateway as a confidential
+	// client (client_secret_post).
+	ClientID     string
+	ClientSecret string
+	// Audience is the resource indicator placed into the swapped token's
+	// `aud` claim. v2 supports a single audience — the backend agent.
+	Audience string
+	// Scope is an optional space-separated scope set requested on the swap.
+	// Empty means no scope narrowing.
+	Scope string
+	// HTTPClient lets tests inject a custom transport. nil → a 10s-timeout
+	// http.Client.
+	HTTPClient *http.Client
+	// CacheTTLCap caps the cache TTL regardless of token expiry. nil/0 →
+	// 5 minutes.
+	CacheTTLCap time.Duration
+	// Now lets tests inject a clock. nil → time.Now.
+	Now func() time.Time
+}
+
+// TokenExchanger swaps an inbound subject token for a downstream-audienced
+// token via RFC 8693. Results are cached in-process keyed by
+// sha256(subject_token); the raw user JWT is not stored.
+type TokenExchanger struct {
+	cfg        TokenExchangeConfig
+	httpClient *http.Client
+	cache      sync.Map // string → cachedToken
+	now        func() time.Time
+	cacheCap   time.Duration
+}
+
+type cachedToken struct {
+	token   string
+	expires time.Time
+}
+
+// NewTokenExchanger validates the config and returns an exchanger ready to
+// serve concurrent Exchange calls.
+func NewTokenExchanger(cfg TokenExchangeConfig) (*TokenExchanger, error) {
+	if cfg.TokenURL == "" {
+		return nil, fmt.Errorf("auth: token exchange requires TokenURL")
+	}
+	if cfg.ClientID == "" {
+		return nil, fmt.Errorf("auth: token exchange requires ClientID")
+	}
+	if cfg.ClientSecret == "" {
+		return nil, fmt.Errorf("auth: token exchange requires ClientSecret")
+	}
+	if cfg.Audience == "" {
+		return nil, fmt.Errorf("auth: token exchange requires Audience")
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	cap := cfg.CacheTTLCap
+	if cap <= 0 {
+		cap = 5 * time.Minute
+	}
+	return &TokenExchanger{
+		cfg:        cfg,
+		httpClient: httpClient,
+		now:        now,
+		cacheCap:   cap,
+	}, nil
+}
+
+// Exchange returns a swapped token for subjectToken, using the cache when
+// the cached entry is still well within its TTL. Errors wrap
+// ErrExchangeFailed so callers can distinguish degraded-deployment failures
+// from caller-token failures (ErrInvalidToken).
+func (e *TokenExchanger) Exchange(ctx context.Context, subjectToken string) (string, error) {
+	key := cacheKey(subjectToken)
+	if hit, ok := e.cache.Load(key); ok {
+		ct := hit.(cachedToken)
+		if e.now().Before(ct.expires) {
+			return ct.token, nil
+		}
+		e.cache.Delete(key)
+	}
+	swapped, ttl, err := e.fetch(ctx, subjectToken)
+	if err != nil {
+		return "", err
+	}
+	// Subtract a 30s safety margin so we never forward a token that is
+	// about to expire by the time the downstream validates it.
+	cacheTTL := ttl - 30*time.Second
+	if cacheTTL > e.cacheCap {
+		cacheTTL = e.cacheCap
+	}
+	if cacheTTL > 0 {
+		e.cache.Store(key, cachedToken{token: swapped, expires: e.now().Add(cacheTTL)})
+	}
+	return swapped, nil
+}
+
+// cacheKey hashes the subject token so the in-memory cache never holds the
+// raw user JWT. SHA-256 is overkill for a cache key but cheap.
+func cacheKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (e *TokenExchanger) fetch(ctx context.Context, subjectToken string) (string, time.Duration, error) {
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeAccessToken)
+	form.Set("requested_token_type", tokenTypeAccessToken)
+	form.Set("audience", e.cfg.Audience)
+	form.Set("client_id", e.cfg.ClientID)
+	form.Set("client_secret", e.cfg.ClientSecret)
+	if e.cfg.Scope != "" {
+		form.Set("scope", e.cfg.Scope)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("%w: build request: %v", ErrExchangeFailed, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("%w: %v", ErrExchangeFailed, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("%w: %s: %s", ErrExchangeFailed, resp.Status, truncate(string(body), 256))
+	}
+	var payload struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", 0, fmt.Errorf("%w: decode response: %v", ErrExchangeFailed, err)
+	}
+	if payload.AccessToken == "" {
+		return "", 0, fmt.Errorf("%w: empty access_token in response", ErrExchangeFailed)
+	}
+	return payload.AccessToken, time.Duration(payload.ExpiresIn) * time.Second, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/auth/exchange_test.go
+++ b/internal/auth/exchange_test.go
@@ -1,0 +1,331 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fips-agents/gateway-template/internal/auth"
+)
+
+// exchangeFixture stands in for an RFC 8693 token endpoint. It records every
+// inbound request so tests can assert on form fields and cache behaviour.
+type exchangeFixture struct {
+	server   *httptest.Server
+	calls    atomic.Int64
+	lastForm url.Values
+
+	// response controls the next reply.
+	status      int
+	accessToken string
+	expiresIn   int
+	body        string // when non-empty, used verbatim and JSON encoding is skipped
+}
+
+func newExchangeFixture(t *testing.T) *exchangeFixture {
+	t.Helper()
+	f := &exchangeFixture{
+		status:      http.StatusOK,
+		accessToken: "swapped-token-XYZ",
+		expiresIn:   300,
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		_ = r.ParseForm()
+		f.lastForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.status)
+		if f.body != "" {
+			_, _ = w.Write([]byte(f.body))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"access_token":%q,"token_type":"Bearer","expires_in":%d}`, f.accessToken, f.expiresIn)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func newExchanger(t *testing.T, f *exchangeFixture, opts ...func(*auth.TokenExchangeConfig)) *auth.TokenExchanger {
+	t.Helper()
+	cfg := auth.TokenExchangeConfig{
+		TokenURL:     f.server.URL,
+		ClientID:     "gw-svc",
+		ClientSecret: "shh",
+		Audience:     "backend-agent",
+		HTTPClient:   f.server.Client(),
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	ex, err := auth.NewTokenExchanger(cfg)
+	if err != nil {
+		t.Fatalf("NewTokenExchanger: %v", err)
+	}
+	return ex
+}
+
+func TestNewTokenExchanger_RequiresFields(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*auth.TokenExchangeConfig)
+	}{
+		{"missing token url", func(c *auth.TokenExchangeConfig) { c.TokenURL = "" }},
+		{"missing client id", func(c *auth.TokenExchangeConfig) { c.ClientID = "" }},
+		{"missing client secret", func(c *auth.TokenExchangeConfig) { c.ClientSecret = "" }},
+		{"missing audience", func(c *auth.TokenExchangeConfig) { c.Audience = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := auth.TokenExchangeConfig{
+				TokenURL:     "https://kc/realms/x/protocol/openid-connect/token",
+				ClientID:     "id",
+				ClientSecret: "secret",
+				Audience:     "aud",
+			}
+			tc.mut(&cfg)
+			if _, err := auth.NewTokenExchanger(cfg); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestTokenExchanger_HappyPath_PostsRFC8693Form(t *testing.T) {
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f, func(c *auth.TokenExchangeConfig) { c.Scope = "openid email" })
+
+	got, err := ex.Exchange(context.Background(), "user-jwt-input")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if got != "swapped-token-XYZ" {
+		t.Errorf("Exchange returned %q, want %q", got, "swapped-token-XYZ")
+	}
+	if f.calls.Load() != 1 {
+		t.Errorf("expected 1 token-endpoint call, got %d", f.calls.Load())
+	}
+
+	want := map[string]string{
+		"grant_type":           "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":        "user-jwt-input",
+		"subject_token_type":   "urn:ietf:params:oauth:token-type:access_token",
+		"requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+		"audience":             "backend-agent",
+		"client_id":            "gw-svc",
+		"client_secret":        "shh",
+		"scope":                "openid email",
+	}
+	for k, v := range want {
+		if got := f.lastForm.Get(k); got != v {
+			t.Errorf("form[%s] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestTokenExchanger_OmitsScopeWhenEmpty(t *testing.T) {
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f)
+
+	if _, err := ex.Exchange(context.Background(), "user-jwt"); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if _, present := f.lastForm["scope"]; present {
+		t.Errorf("scope should be omitted when not configured, got form %+v", f.lastForm)
+	}
+}
+
+func TestTokenExchanger_CachesByToken(t *testing.T) {
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f)
+
+	for i := 0; i < 3; i++ {
+		got, err := ex.Exchange(context.Background(), "same-input")
+		if err != nil {
+			t.Fatalf("Exchange (iter %d): %v", i, err)
+		}
+		if got != "swapped-token-XYZ" {
+			t.Errorf("Exchange returned %q", got)
+		}
+	}
+	if got := f.calls.Load(); got != 1 {
+		t.Errorf("expected 1 token-endpoint call (cache hits after first), got %d", got)
+	}
+
+	// A different subject token must trigger a fresh call.
+	if _, err := ex.Exchange(context.Background(), "different-input"); err != nil {
+		t.Fatalf("Exchange (different input): %v", err)
+	}
+	if got := f.calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls after distinct input, got %d", got)
+	}
+}
+
+func TestTokenExchanger_CacheRespectsExpiry(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.expiresIn = 60 // 60s server TTL → 30s effective cache TTL after safety margin.
+
+	clock := time.Now()
+	ex := newExchanger(t, f, func(c *auth.TokenExchangeConfig) {
+		c.Now = func() time.Time { return clock }
+	})
+
+	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		t.Fatalf("first Exchange: %v", err)
+	}
+	if got := f.calls.Load(); got != 1 {
+		t.Errorf("expected 1 call, got %d", got)
+	}
+
+	// Within cache TTL → no new call.
+	clock = clock.Add(20 * time.Second)
+	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		t.Fatalf("cached Exchange: %v", err)
+	}
+	if got := f.calls.Load(); got != 1 {
+		t.Errorf("expected 1 call (cache hit), got %d", got)
+	}
+
+	// Past cache TTL (server expires_in 60s − 30s safety margin = 30s cap),
+	// jumping 45s forward should evict.
+	clock = clock.Add(45 * time.Second)
+	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		t.Fatalf("post-expiry Exchange: %v", err)
+	}
+	if got := f.calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls (cache expired), got %d", got)
+	}
+}
+
+func TestTokenExchanger_DoesNotCacheNearExpiryTokens(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.expiresIn = 20 // less than 30s safety margin → never cache
+
+	ex := newExchanger(t, f)
+
+	for i := 0; i < 3; i++ {
+		if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+			t.Fatalf("Exchange (iter %d): %v", i, err)
+		}
+	}
+	if got := f.calls.Load(); got != 3 {
+		t.Errorf("expected 3 calls when ttl < safety margin, got %d", got)
+	}
+}
+
+func TestTokenExchanger_HonoursCacheTTLCap(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.expiresIn = 3600 // server says 1h
+
+	clock := time.Now()
+	ex := newExchanger(t, f, func(c *auth.TokenExchangeConfig) {
+		c.Now = func() time.Time { return clock }
+		c.CacheTTLCap = 2 * time.Minute
+	})
+
+	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		t.Fatalf("first Exchange: %v", err)
+	}
+	// Cap should kick in well before the server's 1h.
+	clock = clock.Add(3 * time.Minute)
+	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		t.Fatalf("post-cap Exchange: %v", err)
+	}
+	if got := f.calls.Load(); got != 2 {
+		t.Errorf("expected 2 calls after cache cap exceeded, got %d", got)
+	}
+}
+
+func TestTokenExchanger_4xxFails(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.status = http.StatusBadRequest
+	f.body = `{"error":"invalid_grant"}`
+
+	ex := newExchanger(t, f)
+
+	_, err := ex.Exchange(context.Background(), "tok")
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+}
+
+func TestTokenExchanger_5xxFails(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.status = http.StatusServiceUnavailable
+	f.body = "upstream down"
+
+	ex := newExchanger(t, f)
+
+	_, err := ex.Exchange(context.Background(), "tok")
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+}
+
+func TestTokenExchanger_MalformedJSONFails(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.body = "not json"
+
+	ex := newExchanger(t, f)
+
+	_, err := ex.Exchange(context.Background(), "tok")
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+}
+
+func TestTokenExchanger_MissingAccessTokenFails(t *testing.T) {
+	f := newExchangeFixture(t)
+	f.body = `{"token_type":"Bearer","expires_in":300}` // no access_token
+
+	ex := newExchanger(t, f)
+
+	_, err := ex.Exchange(context.Background(), "tok")
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+}
+
+func TestTokenExchanger_TransportErrorFails(t *testing.T) {
+	// Point at an unreachable URL — no listener on this port.
+	cfg := auth.TokenExchangeConfig{
+		TokenURL:     "http://127.0.0.1:1/no-such-endpoint",
+		ClientID:     "id",
+		ClientSecret: "secret",
+		Audience:     "aud",
+		HTTPClient:   &http.Client{Timeout: 200 * time.Millisecond},
+	}
+	ex, err := auth.NewTokenExchanger(cfg)
+	if err != nil {
+		t.Fatalf("NewTokenExchanger: %v", err)
+	}
+
+	_, err = ex.Exchange(context.Background(), "tok")
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+}
+
+func TestTokenExchanger_RequestUsesContext(t *testing.T) {
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := ex.Exchange(ctx, "tok")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	// We don't require ErrExchangeFailed here because the canceled-context
+	// failure path may surface as the URL error; we only assert that the
+	// server was not actually contacted.
+	if got := f.calls.Load(); got != 0 {
+		t.Errorf("expected 0 endpoint calls under cancelled context, got %d", got)
+	}
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -48,17 +48,22 @@ type JWTConfig struct {
 // 401 without leaking validation details to the caller. Detailed reasons are
 // logged.
 type JWTAuth struct {
-	cfg     JWTConfig
-	keyfunc jwt.Keyfunc
-	parser  *jwt.Parser
+	cfg       JWTConfig
+	keyfunc   jwt.Keyfunc
+	parser    *jwt.Parser
+	exchanger *TokenExchanger
 }
 
 // NewJWTAuth constructs a JWTAuth. JWKS fetch happens lazily — the first
 // request triggers a fetch, subsequent requests use the cache. This means
 // the gateway can start up while Keycloak is still warming.
 //
+// exchanger is optional. When non-nil, every successful Authenticate call
+// performs an RFC 8693 swap of the inbound subject token before returning,
+// populating Identity.BearerToken with the swapped value.
+//
 // If you need eager JWKS warmup at startup, call (j *JWTAuth).Warm(ctx).
-func NewJWTAuth(cfg JWTConfig) (*JWTAuth, error) {
+func NewJWTAuth(cfg JWTConfig, exchanger *TokenExchanger) (*JWTAuth, error) {
 	if cfg.JWKSURL == "" {
 		return nil, fmt.Errorf("auth: jwt mode requires JWKSURL")
 	}
@@ -92,9 +97,10 @@ func NewJWTAuth(cfg JWTConfig) (*JWTAuth, error) {
 	)
 
 	return &JWTAuth{
-		cfg:     cfg,
-		keyfunc: k.Keyfunc,
-		parser:  parser,
+		cfg:       cfg,
+		keyfunc:   k.Keyfunc,
+		parser:    parser,
+		exchanger: exchanger,
 	}, nil
 }
 
@@ -127,12 +133,27 @@ func (j *JWTAuth) Authenticate(r *http.Request) (Identity, error) {
 		return Identity{}, fmt.Errorf("%w: missing %q claim", ErrInvalidToken, j.cfg.SubjectClaim)
 	}
 
-	return Identity{
+	id := Identity{
 		Subject: subject,
 		User:    stringClaim(claims, j.cfg.UserClaim),
 		Email:   stringClaim(claims, j.cfg.EmailClaim),
 		Mode:    ModeJWT,
-	}, nil
+	}
+
+	if j.exchanger != nil {
+		swapped, err := j.exchanger.Exchange(r.Context(), tokenStr)
+		if err != nil {
+			// Exchange errors flow through ErrExchangeFailed (NOT
+			// ErrInvalidToken). The middleware maps non-ErrInvalidToken
+			// errors to 503 — token exchange that does not succeed means
+			// the gateway cannot vouch for the downstream call, so we fail
+			// closed rather than silently forward an unverifiable identity.
+			return Identity{}, err
+		}
+		id.BearerToken = swapped
+	}
+
+	return id, nil
 }
 
 // bearerToken extracts the token from an `Authorization: Bearer <token>`

--- a/internal/auth/jwt_keycloak_integration_test.go
+++ b/internal/auth/jwt_keycloak_integration_test.go
@@ -163,6 +163,92 @@ func TestJWTAuth_LiveKeycloak_HappyPath(t *testing.T) {
 	}
 }
 
+func TestJWTAuth_LiveKeycloak_TokenExchange(t *testing.T) {
+	if os.Getenv("KC_INTEGRATION") == "" {
+		t.Skip("set KC_INTEGRATION=1 to enable")
+	}
+	if os.Getenv("KC_EXCHANGE_AUDIENCE") == "" {
+		t.Skip("set KC_EXCHANGE_* (run scripts/keycloak-test-setup.sh against Keycloak 26+) to enable")
+	}
+
+	orig := http.DefaultTransport
+	http.DefaultTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // sandbox-only
+	}
+	defer func() { http.DefaultTransport = orig }()
+
+	ex, err := auth.NewTokenExchanger(auth.TokenExchangeConfig{
+		TokenURL:     mustEnv(t, "KC_EXCHANGE_TOKEN_URL"),
+		ClientID:     mustEnv(t, "KC_EXCHANGE_CLIENT_ID"),
+		ClientSecret: mustEnv(t, "KC_EXCHANGE_CLIENT_SECRET"),
+		Audience:     mustEnv(t, "KC_EXCHANGE_AUDIENCE"),
+		HTTPClient:   liveKeycloakHTTPClient(),
+	})
+	if err != nil {
+		t.Fatalf("NewTokenExchanger: %v", err)
+	}
+
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:  mustEnv(t, "KC_JWKS_URL"),
+			Issuer:   mustEnv(t, "KC_ISSUER"),
+			Audience: mustEnv(t, "KC_AUDIENCE"),
+		},
+		JWTExchanger: ex,
+	})
+	if err != nil {
+		t.Fatalf("auth.New(jwt+exchange): %v", err)
+	}
+
+	userTok := fetchUserToken(t,
+		mustEnv(t, "KC_TOKEN_URL"),
+		mustEnv(t, "KC_CLIENT_ID"),
+		mustEnv(t, "KC_CLIENT_SECRET"),
+		mustEnv(t, "KC_USERNAME"),
+		mustEnv(t, "KC_PASSWORD"),
+	)
+
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r.Header.Set("Authorization", "Bearer "+userTok)
+
+	id, err := a.Authenticate(r)
+	if err != nil {
+		t.Fatalf("Authenticate (with exchange): %v", err)
+	}
+	if id.BearerToken == "" {
+		t.Fatal("expected non-empty BearerToken from exchange, got empty")
+	}
+	if id.BearerToken == userTok {
+		t.Error("BearerToken equals input — Keycloak did not actually swap the token")
+	}
+
+	// Round-trip the swapped token through a fresh validator pointed at
+	// the *exchange* audience. Successful validation proves: Keycloak
+	// signed the swap (cryptographic assertion), aud matches the
+	// downstream resource the gateway requested, and any downstream MCP
+	// server using the same JWKS can verify the swap the same way.
+	downstream, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:  mustEnv(t, "KC_JWKS_URL"),
+			Issuer:   mustEnv(t, "KC_ISSUER"),
+			Audience: mustEnv(t, "KC_EXCHANGE_AUDIENCE"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("downstream validator: %v", err)
+	}
+
+	r2 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r2.Header.Set("Authorization", "Bearer "+id.BearerToken)
+	swapID, err := downstream.Authenticate(r2)
+	if err != nil {
+		t.Fatalf("downstream validation of swapped token: %v", err)
+	}
+	if swapID.Subject != id.Subject {
+		t.Errorf("swapped sub %q != original sub %q (user identity must be preserved through the swap)", swapID.Subject, id.Subject)
+	}
+}
+
 func TestJWTAuth_LiveKeycloak_RejectsTamperedToken(t *testing.T) {
 	if os.Getenv("KC_INTEGRATION") == "" {
 		t.Skip("set KC_INTEGRATION=1 to enable")

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -361,6 +361,88 @@ func TestJWTAuth_RejectsNoneAlg(t *testing.T) {
 	}
 }
 
+// newJWTAuthWithExchanger constructs a JWTAuth backed by f's JWKS and the
+// supplied TokenExchanger. Mirrors newJWTAuth but exercises the exchange
+// path so we can assert Identity.BearerToken behaviour.
+func newJWTAuthWithExchanger(t *testing.T, f *jwksFixture, ex *auth.TokenExchanger) auth.Authenticator {
+	t.Helper()
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:  f.server.URL,
+			Issuer:   testIssuer,
+			Audience: testAudience,
+		},
+		JWTExchanger: ex,
+	})
+	if err != nil {
+		t.Fatalf("New(jwt+exchanger): %v", err)
+	}
+	return a
+}
+
+func TestJWTAuth_WithExchanger_PopulatesBearerToken(t *testing.T) {
+	f := newJWKSFixture(t)
+	xf := newExchangeFixture(t)
+	xf.accessToken = "swapped-for-backend"
+
+	ex := newExchanger(t, xf)
+	a := newJWTAuthWithExchanger(t, f, ex)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	id, err := a.Authenticate(reqWithBearer(tok))
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if id.BearerToken != "swapped-for-backend" {
+		t.Errorf("Identity.BearerToken: got %q, want %q", id.BearerToken, "swapped-for-backend")
+	}
+	// Other identity fields should still resolve from the inbound JWT.
+	if id.Subject != "user-123" || id.Mode != auth.ModeJWT {
+		t.Errorf("identity: got %+v", id)
+	}
+	if got := xf.calls.Load(); got != 1 {
+		t.Errorf("expected 1 token-exchange call, got %d", got)
+	}
+	// The exchange must receive the inbound subject token verbatim.
+	if got := xf.lastForm.Get("subject_token"); got != tok {
+		t.Errorf("exchange subject_token: got %q, want inbound JWT", got)
+	}
+}
+
+func TestJWTAuth_WithExchanger_FailureSurfacesAsExchangeFailed(t *testing.T) {
+	f := newJWKSFixture(t)
+	xf := newExchangeFixture(t)
+	xf.status = http.StatusBadGateway
+
+	ex := newExchanger(t, xf)
+	a := newJWTAuthWithExchanger(t, f, ex)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	_, err := a.Authenticate(reqWithBearer(tok))
+	if !errors.Is(err, auth.ErrExchangeFailed) {
+		t.Fatalf("want ErrExchangeFailed, got %v", err)
+	}
+	// Crucially: NOT ErrInvalidToken. The middleware must distinguish
+	// degraded-deployment failures from caller-token failures.
+	if errors.Is(err, auth.ErrInvalidToken) {
+		t.Errorf("exchange failure must not present as ErrInvalidToken: %v", err)
+	}
+}
+
+func TestJWTAuth_WithoutExchanger_LeavesBearerTokenEmpty(t *testing.T) {
+	f := newJWKSFixture(t)
+	a := newJWTAuth(t, f, testIssuer, testAudience)
+
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	id, err := a.Authenticate(reqWithBearer(tok))
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if id.BearerToken != "" {
+		t.Errorf("Identity.BearerToken should be empty when no exchanger configured, got %q", id.BearerToken)
+	}
+}
+
 // Sanity check that the fixture itself round-trips, so a real failure in
 // the validation path can be told apart from a fixture bug.
 func TestJWKSFixture_RoundTrip(t *testing.T) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -64,9 +64,23 @@ func Middleware(a Authenticator) func(http.Handler) http.Handler {
 			}
 
 			setCanonicalHeaders(r.Header, id)
+			projectAuthorization(r.Header, id)
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// projectAuthorization replaces the inbound Authorization header with the
+// gateway-derived bearer token (e.g. an RFC 8693 swapped token) when the
+// strategy populated id.BearerToken. Otherwise it strips Authorization so
+// the raw inbound bearer never leaks downstream — the gateway forwards only
+// what it can vouch for.
+func projectAuthorization(h http.Header, id Identity) {
+	if id.BearerToken != "" {
+		h.Set("Authorization", "Bearer "+id.BearerToken)
+		return
+	}
+	h.Del("Authorization")
 }
 
 // stripCanonicalHeaders removes any inbound copies of the canonical X-Auth-*

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -214,3 +214,47 @@ type stubAuth struct {
 func (s stubAuth) Authenticate(*http.Request) (auth.Identity, error) {
 	return s.id, s.err
 }
+
+// TestMiddleware_StripsInboundAuthorizationByDefault ensures that, when the
+// strategy resolves an Identity without a BearerToken, the inbound
+// Authorization header does not leak through to the handler. The gateway
+// should never forward a bearer token it has not derived itself.
+func TestMiddleware_StripsInboundAuthorizationByDefault(t *testing.T) {
+	cap := &captureHandler{}
+	h := auth.Middleware(&auth.AnonymousAuth{})(cap)
+
+	req := httptest.NewRequest("POST", "/v1/feedback", nil)
+	req.Header.Set("Authorization", "Bearer raw-user-jwt")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := cap.got.Get("Authorization"); got != "" {
+		t.Errorf("inbound Authorization leaked through: got %q", got)
+	}
+}
+
+// TestMiddleware_ProjectsBearerTokenFromIdentity verifies that when the
+// strategy populates Identity.BearerToken (e.g. an RFC 8693 swapped token),
+// the middleware writes it as `Authorization: Bearer <token>` so handlers
+// can forward it to the backend.
+func TestMiddleware_ProjectsBearerTokenFromIdentity(t *testing.T) {
+	cap := &captureHandler{}
+	stub := stubAuth{id: auth.Identity{
+		Subject:     "user-123",
+		Mode:        auth.ModeJWT,
+		BearerToken: "swapped-for-backend",
+	}}
+	h := auth.Middleware(stub)(cap)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	// Inbound Authorization (the user's JWT) must be replaced by the swap.
+	req.Header.Set("Authorization", "Bearer raw-user-jwt")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := cap.got.Get("Authorization"); got != "Bearer swapped-for-backend" {
+		t.Errorf("Authorization: got %q, want %q", got, "Bearer swapped-for-backend")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,27 @@ type Config struct {
 	AuthJWTSubjectClaim string
 	AuthJWTUserClaim    string
 	AuthJWTEmailClaim   string
+
+	// Token exchange (RFC 8693): consulted only when AuthMode == "jwt".
+	// When all four required fields (URL, ClientID, ClientSecret, Audience)
+	// are non-empty, the gateway swaps the inbound user JWT for a
+	// downstream-audienced token before forwarding to the backend. Partial
+	// configuration (some set, some empty) is rejected at Load() time.
+	AuthJWTExchangeURL          string
+	AuthJWTExchangeClientID     string
+	AuthJWTExchangeClientSecret string
+	AuthJWTExchangeAudience     string
+	AuthJWTExchangeScope        string
+}
+
+// JWTExchangeEnabled reports whether all four required token-exchange
+// fields are populated. Used by the wiring layer to decide whether to
+// construct a TokenExchanger.
+func (c *Config) JWTExchangeEnabled() bool {
+	return c.AuthJWTExchangeURL != "" &&
+		c.AuthJWTExchangeClientID != "" &&
+		c.AuthJWTExchangeClientSecret != "" &&
+		c.AuthJWTExchangeAudience != ""
 }
 
 // Load reads configuration from environment variables and validates required fields.
@@ -46,12 +67,17 @@ func Load() (*Config, error) {
 		AuthMode:             envOrDefault("GATEWAY_AUTH_MODE", "anonymous"),
 		AuthProxyUserHeader:  envOrDefault("GATEWAY_AUTH_PROXY_USER_HEADER", "X-Forwarded-User"),
 		AuthProxyEmailHeader: envOrDefault("GATEWAY_AUTH_PROXY_EMAIL_HEADER", "X-Forwarded-Email"),
-		AuthJWTJWKSURL:       os.Getenv("GATEWAY_AUTH_JWT_JWKS_URL"),
-		AuthJWTIssuer:        os.Getenv("GATEWAY_AUTH_JWT_ISSUER"),
-		AuthJWTAudience:      os.Getenv("GATEWAY_AUTH_JWT_AUDIENCE"),
-		AuthJWTSubjectClaim:  envOrDefault("GATEWAY_AUTH_JWT_SUBJECT_CLAIM", "sub"),
-		AuthJWTUserClaim:     envOrDefault("GATEWAY_AUTH_JWT_USER_CLAIM", "preferred_username"),
-		AuthJWTEmailClaim:    envOrDefault("GATEWAY_AUTH_JWT_EMAIL_CLAIM", "email"),
+		AuthJWTJWKSURL:              os.Getenv("GATEWAY_AUTH_JWT_JWKS_URL"),
+		AuthJWTIssuer:               os.Getenv("GATEWAY_AUTH_JWT_ISSUER"),
+		AuthJWTAudience:             os.Getenv("GATEWAY_AUTH_JWT_AUDIENCE"),
+		AuthJWTSubjectClaim:         envOrDefault("GATEWAY_AUTH_JWT_SUBJECT_CLAIM", "sub"),
+		AuthJWTUserClaim:            envOrDefault("GATEWAY_AUTH_JWT_USER_CLAIM", "preferred_username"),
+		AuthJWTEmailClaim:           envOrDefault("GATEWAY_AUTH_JWT_EMAIL_CLAIM", "email"),
+		AuthJWTExchangeURL:          os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL"),
+		AuthJWTExchangeClientID:     os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID"),
+		AuthJWTExchangeClientSecret: os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET"),
+		AuthJWTExchangeAudience:     os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE"),
+		AuthJWTExchangeScope:        os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE"),
 	}
 
 	if cfg.BackendURL == "" {
@@ -67,9 +93,38 @@ func Load() (*Config, error) {
 		if cfg.AuthJWTAudience == "" {
 			return nil, fmt.Errorf("GATEWAY_AUTH_JWT_AUDIENCE is required when GATEWAY_AUTH_MODE=jwt")
 		}
+		if err := validateExchangeConfig(cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil
+}
+
+// validateExchangeConfig fails closed on partially-configured token
+// exchange. Either all four required fields are set (exchange enabled) or
+// none are (exchange disabled). Anything in between is almost certainly a
+// deployment bug — flag it loudly at startup rather than silently disabling
+// the swap.
+func validateExchangeConfig(cfg *Config) error {
+	required := map[string]string{
+		"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL":           cfg.AuthJWTExchangeURL,
+		"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID":     cfg.AuthJWTExchangeClientID,
+		"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET": cfg.AuthJWTExchangeClientSecret,
+		"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE":      cfg.AuthJWTExchangeAudience,
+	}
+	var setNames, missingNames []string
+	for name, val := range required {
+		if val != "" {
+			setNames = append(setNames, name)
+		} else {
+			missingNames = append(missingNames, name)
+		}
+	}
+	if len(setNames) > 0 && len(missingNames) > 0 {
+		return fmt.Errorf("token exchange is partially configured: %v set but %v missing — set all four or none", setNames, missingNames)
+	}
+	return nil
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,108 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fips-agents/gateway-template/internal/config"
+)
+
+// jwtBaseEnv returns the minimum env vars needed for AuthMode=jwt to pass
+// validation. Tests can override individual entries before calling
+// loadWithEnv.
+func jwtBaseEnv() map[string]string {
+	return map[string]string{
+		"BACKEND_URL":                "http://backend:8081",
+		"GATEWAY_AUTH_MODE":          "jwt",
+		"GATEWAY_AUTH_JWT_JWKS_URL":  "https://kc/realms/x/protocol/openid-connect/certs",
+		"GATEWAY_AUTH_JWT_ISSUER":    "https://kc/realms/x",
+		"GATEWAY_AUTH_JWT_AUDIENCE":  "gateway-template",
+	}
+}
+
+// loadWithEnv sets env vars for the lifetime of t and calls config.Load.
+func loadWithEnv(t *testing.T, env map[string]string) (*config.Config, error) {
+	t.Helper()
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+	return config.Load()
+}
+
+func TestLoad_JWTExchange_AllFieldsSet(t *testing.T) {
+	env := jwtBaseEnv()
+	env["GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL"] = "https://kc/realms/x/protocol/openid-connect/token"
+	env["GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID"] = "gw-svc"
+	env["GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET"] = "shh"
+	env["GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE"] = "backend-agent"
+
+	cfg, err := loadWithEnv(t, env)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.JWTExchangeEnabled() {
+		t.Fatal("JWTExchangeEnabled() = false, want true")
+	}
+}
+
+func TestLoad_JWTExchange_NoFieldsSet(t *testing.T) {
+	cfg, err := loadWithEnv(t, jwtBaseEnv())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.JWTExchangeEnabled() {
+		t.Fatal("JWTExchangeEnabled() = true with no exchange fields set, want false")
+	}
+}
+
+func TestLoad_JWTExchange_PartialConfigRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		setKeys []string
+	}{
+		{"only url", []string{"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL"}},
+		{"url+client_id", []string{
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL",
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID",
+		}},
+		{"missing audience", []string{
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL",
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID",
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET",
+		}},
+		{"missing secret", []string{
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL",
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID",
+			"GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := jwtBaseEnv()
+			for _, k := range tc.setKeys {
+				env[k] = "value"
+			}
+			_, err := loadWithEnv(t, env)
+			if err == nil {
+				t.Fatal("expected error on partial token-exchange config, got nil")
+			}
+			if !strings.Contains(err.Error(), "token exchange") {
+				t.Errorf("error message should mention token exchange, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_JWTExchange_NotConsultedInAnonymousMode(t *testing.T) {
+	// Setting exchange env vars while in anonymous mode should not trigger
+	// the partial-config validator. They're inert outside jwt mode, so
+	// leaving them set during a mode flip should not break startup.
+	t.Setenv("BACKEND_URL", "http://backend:8081")
+	t.Setenv("GATEWAY_AUTH_MODE", "anonymous")
+	t.Setenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL", "https://kc/.../token")
+	// (deliberately leave the other three unset)
+
+	if _, err := config.Load(); err != nil {
+		t.Fatalf("Load in anonymous mode should ignore exchange env vars: %v", err)
+	}
+}

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -112,13 +112,20 @@ func (h *ChatHandler) proxyStreaming(w http.ResponseWriter, r *http.Request, bod
 	proxy.RelaySSE(resp, w)
 }
 
-// forwardedAuthHeaders are the canonical X-Auth-* headers projected by the
-// auth middleware and forwarded to the backend agent.
+// forwardedAuthHeaders are the auth-related headers projected by the auth
+// middleware and forwarded to the backend agent.
+//
+// Authorization is included so jwt-mode token-exchange (RFC 8693) works:
+// the middleware replaces the inbound user JWT with a downstream-audienced
+// swapped token (Identity.BearerToken) before the handler runs, or strips
+// Authorization entirely when no swap is configured. We never forward the
+// raw inbound user JWT.
 var forwardedAuthHeaders = []string{
 	"X-Auth-Subject",
 	"X-Auth-User",
 	"X-Auth-Email",
 	"X-Auth-Mode",
+	"Authorization",
 }
 
 // doBackendRequest sends the request body to the backend's chat completions

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -300,6 +300,71 @@ func TestChatHandler_ForwardsCanonicalAuthHeaders(t *testing.T) {
 	}
 }
 
+func TestChatHandler_ForwardsAuthorization(t *testing.T) {
+	// In jwt mode with token exchange, the auth middleware replaces the
+	// inbound user JWT with a downstream-audienced swapped token on the
+	// request before the handler runs. The handler must forward that
+	// Authorization header to the backend.
+	var captured http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"chatcmpl-x"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.ChatHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	reqBody := `{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer swapped-for-backend")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if got := captured.Get("Authorization"); got != "Bearer swapped-for-backend" {
+		t.Errorf("Authorization not forwarded: got %q", got)
+	}
+}
+
+func TestChatHandler_OmitsAuthorizationWhenAbsent(t *testing.T) {
+	// When the auth middleware strips Authorization (no swap configured,
+	// anonymous mode, etc.), the handler must not invent one or forward
+	// anything. The backend should receive no Authorization header.
+	var captured http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"chatcmpl-x"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.ChatHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	reqBody := `{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization on inbound — simulates middleware having stripped it.
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be absent on backend request, got %q", got)
+	}
+}
+
 func TestChatHandler_StreamingBackendError(t *testing.T) {
 	// Backend returns 500 on a streaming request -- gateway should forward the
 	// error status rather than switching to SSE mode.

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -7,15 +7,21 @@ import (
 	"net/http"
 )
 
-// authHeaders are the canonical X-Auth-* headers forwarded to the backend so
-// it can attribute feedback to the calling user. The auth middleware
-// populates these from the resolved Identity; inbound spoofed copies are
-// stripped before any handler runs. Other headers are dropped.
+// authHeaders are the auth-related headers forwarded to the backend so it
+// can attribute feedback to the calling user. The auth middleware populates
+// these from the resolved Identity; inbound spoofed copies are stripped
+// before any handler runs. Other headers are dropped.
+//
+// Authorization is included so jwt-mode token-exchange (RFC 8693) works:
+// the middleware replaces the inbound user JWT with a downstream-audienced
+// swapped token before the handler runs, or strips Authorization when no
+// swap is configured. We never forward the raw inbound user JWT.
 var authHeaders = []string{
 	"X-Auth-Subject",
 	"X-Auth-User",
 	"X-Auth-Email",
 	"X-Auth-Mode",
+	"Authorization",
 }
 
 // FeedbackHandler proxies user feedback API requests to the backend agent

--- a/internal/handler/feedback_test.go
+++ b/internal/handler/feedback_test.go
@@ -44,8 +44,11 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 
 	// The auth middleware would normally project these from the resolved
 	// Identity. Tests bypass the middleware so we set them directly to
-	// assert that the gateway forwards canonical headers and drops the
-	// pre-cutover ones.
+	// assert what the gateway forwards. Authorization is now part of the
+	// auth contract (jwt-mode token exchange relies on the middleware
+	// placing a swapped token there); the handler trusts whatever the
+	// middleware put on the request. The middleware is responsible for
+	// ensuring it is never the raw inbound user JWT.
 	reqBody := `{"trace_id":"tr_1","rating":1,"comment":"great"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/feedback", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
@@ -53,8 +56,8 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 	req.Header.Set("X-Auth-User", "alice")
 	req.Header.Set("X-Auth-Email", "alice@example.com")
 	req.Header.Set("X-Auth-Mode", "proxy")
-	// Pre-cutover headers — must be dropped, not forwarded.
-	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("Authorization", "Bearer middleware-curated-token")
+	// Non-auth headers must still be dropped.
 	req.Header.Set("X-User-ID", "user-42")
 	rec := httptest.NewRecorder()
 
@@ -78,8 +81,8 @@ func TestFeedbackHandler_PostProxy(t *testing.T) {
 	if capturedMode != "proxy" {
 		t.Errorf("X-Auth-Mode not forwarded: got %q", capturedMode)
 	}
-	if capturedAuthorization != "" {
-		t.Errorf("Authorization header should be dropped, got %q", capturedAuthorization)
+	if capturedAuthorization != "Bearer middleware-curated-token" {
+		t.Errorf("Authorization not forwarded: got %q", capturedAuthorization)
 	}
 	if capturedXUserID != "" {
 		t.Errorf("X-User-ID header should be dropped, got %q", capturedXUserID)

--- a/scripts/keycloak-test-setup.sh
+++ b/scripts/keycloak-test-setup.sh
@@ -22,6 +22,7 @@ NS="${KC_NAMESPACE:-keycloak}"
 POD="${KC_POD:-keycloak-0}"
 REALM="${KC_TEST_REALM:-gateway-template-test}"
 CLIENT_ID="${KC_TEST_CLIENT_ID:-gateway-template}"
+TARGET_CLIENT_ID="${KC_TEST_TARGET_CLIENT_ID:-gateway-template-backend}"
 USER_NAME="${KC_TEST_USER:-alice}"
 USER_PASS="${KC_TEST_USER_PASSWORD:-alicepw}"
 USER_EMAIL="${KC_TEST_USER_EMAIL:-alice@example.test}"
@@ -104,6 +105,41 @@ kcq create "clients/${CLIENT_UUID}/protocol-mappers/models" -r "$REALM" \
   -s 'config."access.token.claim"=true' \
   -s 'config."id.token.claim"=false'
 
+# --- RFC 8693 token exchange (auth v2 part 2) ---
+#
+# Enable Keycloak's "Standard Token Exchange" (token exchange v2) on the
+# source client. With this attribute set, the gateway client can call
+# /token with grant_type=token-exchange to swap a user-bearing token for
+# one audienced at a different client.
+#
+# Requires Keycloak 26+ on the server. Older Keycloak deployments need
+# the legacy fine-grained-permissions model (not configured here).
+kcq update "clients/${CLIENT_UUID}" -r "$REALM" \
+  -s 'attributes."standard.token.exchange.enabled"=true'
+
+# Create the target client that the swapped token will be audienced at.
+# This represents the downstream resource (in the gateway's case: the
+# backend agent). It needs no credentials of its own — it only exists so
+# the swap has a valid `audience` to point at.
+TARGET_UUID=$(kc create clients -r "$REALM" \
+  -s "clientId=${TARGET_CLIENT_ID}" \
+  -s "publicClient=true" \
+  -s "directAccessGrantsEnabled=false" \
+  -s "serviceAccountsEnabled=false" \
+  -s "standardFlowEnabled=false" \
+  -i 2>/dev/null | tr -d '\r\n')
+
+# Add an audience mapper on the source client so the swapped token's
+# `aud` claim contains the target client. Without this, the swap returns
+# a token with aud=${CLIENT_ID}, defeating the point.
+kcq create "clients/${CLIENT_UUID}/protocol-mappers/models" -r "$REALM" \
+  -s "name=aud-${TARGET_CLIENT_ID}" \
+  -s "protocol=openid-connect" \
+  -s "protocolMapper=oidc-audience-mapper" \
+  -s 'config."included.client.audience"='"${TARGET_CLIENT_ID}" \
+  -s 'config."access.token.claim"=true' \
+  -s 'config."id.token.claim"=false'
+
 cat <<EOF
 export KC_INTEGRATION=1
 export KC_ISSUER="${ISSUER}"
@@ -115,4 +151,8 @@ export KC_CLIENT_SECRET="test-secret"
 export KC_USERNAME="${USER_NAME}"
 export KC_PASSWORD="${USER_PASS}"
 export KC_USER_EMAIL="${USER_EMAIL}"
+export KC_EXCHANGE_TOKEN_URL="${TOKEN_URL}"
+export KC_EXCHANGE_CLIENT_ID="${CLIENT_ID}"
+export KC_EXCHANGE_CLIENT_SECRET="test-secret"
+export KC_EXCHANGE_AUDIENCE="${TARGET_CLIENT_ID}"
 EOF


### PR DESCRIPTION
Closes #23.

Auth v2 part 1 (jwt mode, in-process JWKS) shipped in #25. This PR adds part 2: RFC 8693 token exchange.

## What changes for the operator

When you set the four `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_*` env vars (or the equivalent `auth.jwt.exchange.*` Helm values) together, the gateway, after validating the inbound user JWT, calls the configured token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` and forwards the swapped token to the backend as `Authorization: Bearer <swapped>`. The backend (or any next hop) validates against the same JWKS — cryptographic proof of "gateway acting on behalf of user", no trust-the-header.

When you don't set them, the canonical `X-Auth-*` header contract is unchanged and `Authorization` is stripped from the inbound request before it reaches the backend (no leak of the raw user JWT downstream). All three existing modes — anonymous / proxy / jwt without exchange — behave identically to v1.

## Decisions, not in the diff

- **Cache.** In-process, keyed by `sha256(subject_token)` so the raw user JWT is never stored. TTL = `min(token-expiry − 30s, 5min)`. Stdlib only.
- **Failure mode.** Exchange failure → 503 (degraded), not 401. Whole point is signed assertion; falling back to no-exchange would defeat it.
- **Audience.** Single configured audience for v2 — gateway has one downstream (the backend agent). Per-route audiences would belong in a follow-up.
- **Partial config.** Some required fields set, others not → reject at startup. A typo in a Helm value should fail loudly, not silently disable the swap.
- **`act` claim.** Keycloak's standard token exchange v2 leaves `sub` as the user without nesting an actor. Matching Kagenti's exact `act.sub` shape needs custom mappers / SPIFFE / SPIRE; deferred. The integration test asserts the swap occurred, the audience matches, and the user's `sub` survives — which is the cryptographic value v2 was meant to deliver.

## Commit-by-commit story

1. `auth: Add RFC 8693 token exchange client (no wiring)` — `TokenExchanger` + cache + 13 unit tests
2. `auth: Plumb swapped token through Identity.BearerToken and middleware` — Identity field, JWTAuth wires the exchanger, middleware writes/strips Authorization
3. `handler: Forward Authorization header to backend` — chat + feedback handlers add Authorization to the forwarded allowlist; an existing assertion that pre-cutover Authorization was dropped is flipped to match the new contract
4. `config: Surface GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_* env vars` — five new env vars with partial-config rejection
5. `scripts: Provision token exchange in keycloak-test-setup.sh` — enables Keycloak 26+ standard token exchange v2 on the source client, creates a target audience client, exports `KC_EXCHANGE_*`
6. `test: Live Keycloak coverage for token exchange` — `TestJWTAuth_LiveKeycloak_TokenExchange` round-trips a swap through a fresh validator
7. `chart: Surface auth.jwt.exchange.* values, bump to 0.4.0` — Helm values, configmap fields, deployment env from `secretKeyRef`, chart bump
8. `docs: README + CLAUDE.md token-exchange coverage`

## Risks

- **Keycloak version.** The bootstrap script uses the Keycloak 26+ "Standard Token Exchange" client attribute (`standard.token.exchange.enabled=true`). Older Keycloak deployments using fine-grained admin permissions are not covered — script comment flags this. The integration test skips when `KC_EXCHANGE_AUDIENCE` is unset, so happy-path JWT tests remain green on older clusters.
- **`MicahParks/keyfunc/v3` rate limiter** (existing operational finding) — unchanged exposure; swapped tokens are signed by the same realm key as inbound.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` clean
- [x] `helm template` renders cleanly with exchange off (default)
- [x] `helm template` renders cleanly with exchange on (`secretKeyRef` env var present)
- [x] `helm template` rejects exchange.enabled=true with missing required fields
- [ ] Run `scripts/keycloak-test-setup.sh` against `mcp-rhoai/keycloak`, then `go test -tags integration -run TestJWTAuth_LiveKeycloak ./internal/auth/...` — verifies the live-Keycloak exchange path. (Cluster step, run before merge.)