### PR TITLE
feat: Platform routing for /v1/{feedback,sessions,traces}/* — closes #30

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,22 @@ This is a thin reverse proxy -- minimal external dependencies. The core proxy an
 
 ```
 Client --> Gateway (:8080) --> Backend Agent
+                       \---> Platform (optional, when GATEWAY_PLATFORM_URL set)
              |
              +-- /v1/chat/completions  (POST, sync + SSE streaming, propagates X-Trace-Id)
-             +-- /v1/feedback          (POST/GET, pass-through, forwards auth headers)
-             +-- /v1/feedback/{id}     (PATCH, in-place edit of an existing record)
-             +-- /v1/feedback/stats    (GET, pass-through)
+             +-- /v1/feedback          (POST/GET, pass-through, forwards auth headers; routable to platform)
+             +-- /v1/feedback/{id}     (PATCH, in-place edit; routable to platform)
+             +-- /v1/feedback/stats    (GET, pass-through; routable to platform)
+             +-- /v1/sessions/*        (any method, opaque proxy; routable to platform)
+             +-- /v1/sessions/{id}/usage (GET, agent-only — pricing computed in-process)
+             +-- /v1/traces/*          (any method, opaque proxy; routable to platform)
              +-- /v1/agent-info        (GET, pass-through to backend)
              +-- /healthz              (GET, liveness)
              +-- /readyz               (GET, checks backend)
              +-- /.well-known/agent.json (GET, agent card)
 ```
+
+**Platform routing mode (gateway-template#30, chart 0.5.0).** When `GATEWAY_PLATFORM_URL` is set, the three persistence prefixes (`/v1/feedback*`, `/v1/sessions/*`, `/v1/traces/*`) proxy to a deployed [`fipsagents-platform`](https://github.com/fips-agents/fipsagents-platform) service instead of fanning out to per-agent backends. Per-prefix toggles (`GATEWAY_PLATFORM_ROUTE_{FEEDBACK,SESSIONS,TRACES}`) default to `true` when `PLATFORM_URL` is set; flip individual ones to `false` to keep that prefix on the agent. `GET /v1/sessions/{id}/usage` is always agent-routed because it computes USD cost from the agent's `PricingConfig` and is not a platform endpoint. The forwarding handler (`internal/handler/forward.go`, `httputil.ReverseProxy`-based) preserves method, body, query string, `Authorization`, `X-Auth-*`, `X-Tenant`, and `traceparent` headers verbatim — it does not parse request bodies.
 
 Key packages:
 - `cmd/server/` -- entry point, wiring, graceful shutdown
@@ -71,6 +77,10 @@ Key packages:
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) gateway service-account client secret |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE` | exchange | -- | (`jwt` mode) downstream audience the swapped token targets |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE` | No | -- | (`jwt` mode) optional space-separated scope set requested on the swap |
+| `GATEWAY_PLATFORM_URL` | No | -- | Base URL of a deployed `fipsagents-platform` service. When set, persistence prefixes proxy here; trailing slash trimmed. |
+| `GATEWAY_PLATFORM_ROUTE_FEEDBACK` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/feedback*` to platform. Set `false` to keep on agent. No-op when `PLATFORM_URL` unset. |
+| `GATEWAY_PLATFORM_ROUTE_SESSIONS` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/sessions/*` to platform (except `/usage`, always agent). Set `false` to keep on agent. |
+| `GATEWAY_PLATFORM_ROUTE_TRACES` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/traces/*` to platform. Set `false` to keep on agent. |
 
 ## Auth contract
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 description: Go HTTP gateway for AI agents

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -11,6 +11,14 @@ data:
   GATEWAY_AUTH_MODE: {{ .Values.auth.mode | quote }}
   GATEWAY_AUTH_PROXY_USER_HEADER: {{ .Values.auth.proxy.userHeader | quote }}
   GATEWAY_AUTH_PROXY_EMAIL_HEADER: {{ .Values.auth.proxy.emailHeader | quote }}
+  {{- with .Values.platform }}
+  {{- if .url }}
+  GATEWAY_PLATFORM_URL: {{ .url | quote }}
+  GATEWAY_PLATFORM_ROUTE_FEEDBACK: {{ .feedback | default false | quote }}
+  GATEWAY_PLATFORM_ROUTE_SESSIONS: {{ .sessions | default false | quote }}
+  GATEWAY_PLATFORM_ROUTE_TRACES: {{ .traces | default false | quote }}
+  {{- end }}
+  {{- end }}
   {{- if eq .Values.auth.mode "jwt" }}
   GATEWAY_AUTH_JWT_JWKS_URL: {{ required "auth.jwt.jwksUrl is required when auth.mode=jwt" .Values.auth.jwt.jwksUrl | quote }}
   GATEWAY_AUTH_JWT_ISSUER: {{ required "auth.jwt.issuer is required when auth.mode=jwt" .Values.auth.jwt.issuer | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,6 +83,26 @@ auth:
       # means no scope narrowing.
       scope: ""
 
+# -- Platform service routing (gateway-template#30) --------------------------
+# When `platform.url` is set, /v1/feedback*, /v1/sessions/*, and /v1/traces/*
+# proxy to the deployed fipsagents-platform service instead of fanning out
+# to per-agent backends. Each prefix has an opt-out toggle so a deployment
+# can mix backends — eg keep sessions on the agent (so the agent's
+# /v1/sessions/{id}/usage endpoint stays in-process) while routing
+# feedback and traces to the platform.
+#
+# When `platform.url` is empty (default), behavior is unchanged from 0.4.x:
+# every prefix proxies to the agent referenced by config.BACKEND_URL.
+#
+# GET /v1/sessions/{id}/usage always proxies to the agent regardless of
+# the sessions toggle — that endpoint computes USD cost from the agent's
+# PricingConfig and is not implemented on the platform.
+platform:
+  url: ""        # eg http://fipsagents-platform.fipsagents-platform.svc.cluster.local:8080
+  feedback: true
+  sessions: true
+  traces: true
+
 service:
   port: 8080
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,17 +66,45 @@ func main() {
 		BackendURL: cfg.BackendURL,
 		Client:     client,
 	})
-	feedbackHandler := &handler.FeedbackHandler{BackendURL: cfg.BackendURL, Client: client}
+	feedbackTarget := cfg.FeedbackTargetURL()
+	feedbackHandler := &handler.FeedbackHandler{BackendURL: feedbackTarget, Client: client}
 	mux.Handle("POST /v1/feedback", feedbackHandler)
 	mux.Handle("GET /v1/feedback", feedbackHandler)
 	mux.Handle("GET /v1/feedback/stats", &handler.FeedbackStatsHandler{
-		BackendURL: cfg.BackendURL,
+		BackendURL: feedbackTarget,
 		Client:     client,
 	})
 	mux.Handle("PATCH /v1/feedback/{feedback_id}", &handler.FeedbackByIdHandler{
-		BackendURL: cfg.BackendURL,
+		BackendURL: feedbackTarget,
 		Client:     client,
 	})
+
+	// /v1/sessions/* and /v1/traces/* are platform-routable. When
+	// PLATFORM_URL is unset they proxy to the backend agent (preserving
+	// existing behavior for deployments that haven't adopted a sibling
+	// fipsagents-platform).  GET /v1/sessions/{id}/usage is carved out
+	// to always go to the agent because /usage layers PricingConfig
+	// over cost_data — it's an agent capability, not a platform one.
+	sessionsForward, err := handler.NewForwardingHandler(cfg.SessionsTargetURL())
+	if err != nil {
+		slog.Error("sessions forward configuration error", "error", err)
+		os.Exit(1)
+	}
+	tracesForward, err := handler.NewForwardingHandler(cfg.TracesTargetURL())
+	if err != nil {
+		slog.Error("traces forward configuration error", "error", err)
+		os.Exit(1)
+	}
+	usageForward, err := handler.NewForwardingHandler(cfg.BackendURL)
+	if err != nil {
+		slog.Error("usage forward configuration error", "error", err)
+		os.Exit(1)
+	}
+	// Go 1.22 mux: the more specific pattern wins, so this carve-out
+	// runs even though /v1/sessions/ catches everything else.
+	mux.Handle("GET /v1/sessions/{session_id}/usage", usageForward)
+	mux.Handle("/v1/sessions/", sessionsForward)
+	mux.Handle("/v1/traces/", tracesForward)
 	mux.Handle("/healthz", &handler.HealthHandler{})
 	mux.Handle("/readyz", &handler.ReadyHandler{
 		BackendURL: cfg.BackendURL,
@@ -120,6 +148,10 @@ func main() {
 		slog.Info("gateway starting",
 			"port", cfg.Port,
 			"backend", cfg.BackendURL,
+			"platform", cfg.PlatformURL,
+			"platform_route_feedback", cfg.PlatformURL != "" && cfg.PlatformRouteFeedback,
+			"platform_route_sessions", cfg.PlatformURL != "" && cfg.PlatformRouteSessions,
+			"platform_route_traces", cfg.PlatformURL != "" && cfg.PlatformRouteTraces,
 			"agent", cfg.AgentName,
 			"version", cfg.AgentVersion,
 			"auth_mode", cfg.AuthMode,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,53 @@ type Config struct {
 	AuthJWTExchangeClientSecret string
 	AuthJWTExchangeAudience     string
 	AuthJWTExchangeScope        string
+
+	// PlatformURL is the base URL of a deployed fipsagents-platform
+	// service. When set, /v1/feedback*, /v1/sessions/*, and /v1/traces/*
+	// route to it instead of fanning out to the per-agent BackendURL.
+	// When empty, gateway behavior is unchanged from 0.4.x — every prefix
+	// proxies to the backend agent.
+	//
+	// Per-prefix toggles allow mixing: eg feedback to platform but
+	// sessions still on the agent. Toggles default to true when
+	// PlatformURL is set; setting them false routes that prefix to the
+	// agent. When PlatformURL is empty, toggles are no-ops.
+	//
+	// GET /v1/sessions/{id}/usage always routes to the agent — that
+	// endpoint computes USD cost from the agent's PricingConfig and is
+	// not implemented on the platform.
+	PlatformURL           string
+	PlatformRouteFeedback bool
+	PlatformRouteSessions bool
+	PlatformRouteTraces   bool
+}
+
+// FeedbackTargetURL returns the base URL that /v1/feedback* requests
+// should be proxied to. When platform routing is enabled for feedback,
+// returns PlatformURL; otherwise falls back to BackendURL.
+func (c *Config) FeedbackTargetURL() string {
+	if c.PlatformURL != "" && c.PlatformRouteFeedback {
+		return c.PlatformURL
+	}
+	return c.BackendURL
+}
+
+// SessionsTargetURL returns the base URL that /v1/sessions/* requests
+// (other than the agent-only /usage carve-out) should be proxied to.
+func (c *Config) SessionsTargetURL() string {
+	if c.PlatformURL != "" && c.PlatformRouteSessions {
+		return c.PlatformURL
+	}
+	return c.BackendURL
+}
+
+// TracesTargetURL returns the base URL that /v1/traces/* requests should
+// be proxied to.
+func (c *Config) TracesTargetURL() string {
+	if c.PlatformURL != "" && c.PlatformRouteTraces {
+		return c.PlatformURL
+	}
+	return c.BackendURL
 }
 
 // JWTExchangeEnabled reports whether all four required token-exchange
@@ -78,6 +125,14 @@ func Load() (*Config, error) {
 		AuthJWTExchangeClientSecret: os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET"),
 		AuthJWTExchangeAudience:     os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE"),
 		AuthJWTExchangeScope:        os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE"),
+
+		PlatformURL: strings.TrimRight(os.Getenv("GATEWAY_PLATFORM_URL"), "/"),
+		// Per-prefix toggles default to true so that setting PLATFORM_URL
+		// alone routes all three prefixes. Operators opt out per-prefix
+		// by setting the toggle to "false".
+		PlatformRouteFeedback: envBoolDefault("GATEWAY_PLATFORM_ROUTE_FEEDBACK", true),
+		PlatformRouteSessions: envBoolDefault("GATEWAY_PLATFORM_ROUTE_SESSIONS", true),
+		PlatformRouteTraces:   envBoolDefault("GATEWAY_PLATFORM_ROUTE_TRACES", true),
 	}
 
 	if cfg.BackendURL == "" {
@@ -136,5 +191,18 @@ func envOrDefault(key, fallback string) string {
 
 func envBool(key string) bool {
 	v := strings.ToLower(os.Getenv(key))
+	return v == "true" || v == "1" || v == "yes"
+}
+
+// envBoolDefault parses a bool env var with an explicit default returned
+// when the variable is unset. Distinct from envBool, which conflates
+// unset with "false". Used for opt-out toggles where unset must mean the
+// default rather than false.
+func envBoolDefault(key string, fallback bool) bool {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	v := strings.ToLower(raw)
 	return v == "true" || v == "1" || v == "yes"
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,6 +93,96 @@ func TestLoad_JWTExchange_PartialConfigRejected(t *testing.T) {
 	}
 }
 
+func TestLoad_PlatformURL_UnsetMeansLegacyFanout(t *testing.T) {
+	cfg, err := loadWithEnv(t, map[string]string{"BACKEND_URL": "http://agent:8080"})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PlatformURL != "" {
+		t.Errorf("PlatformURL = %q, want empty", cfg.PlatformURL)
+	}
+	if got := cfg.FeedbackTargetURL(); got != "http://agent:8080" {
+		t.Errorf("FeedbackTargetURL = %q, want backend URL", got)
+	}
+	if got := cfg.SessionsTargetURL(); got != "http://agent:8080" {
+		t.Errorf("SessionsTargetURL = %q, want backend URL", got)
+	}
+	if got := cfg.TracesTargetURL(); got != "http://agent:8080" {
+		t.Errorf("TracesTargetURL = %q, want backend URL", got)
+	}
+}
+
+func TestLoad_PlatformURL_SetRoutesAllPrefixes(t *testing.T) {
+	cfg, err := loadWithEnv(t, map[string]string{
+		"BACKEND_URL":          "http://agent:8080",
+		"GATEWAY_PLATFORM_URL": "http://platform:8080",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PlatformURL != "http://platform:8080" {
+		t.Errorf("PlatformURL = %q, want platform URL", cfg.PlatformURL)
+	}
+	for name, got := range map[string]string{
+		"feedback": cfg.FeedbackTargetURL(),
+		"sessions": cfg.SessionsTargetURL(),
+		"traces":   cfg.TracesTargetURL(),
+	} {
+		if got != "http://platform:8080" {
+			t.Errorf("%sTargetURL = %q, want platform URL", name, got)
+		}
+	}
+}
+
+func TestLoad_PlatformURL_PerPrefixOptOut(t *testing.T) {
+	cfg, err := loadWithEnv(t, map[string]string{
+		"BACKEND_URL":                     "http://agent:8080",
+		"GATEWAY_PLATFORM_URL":            "http://platform:8080",
+		"GATEWAY_PLATFORM_ROUTE_SESSIONS": "false",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.SessionsTargetURL(); got != "http://agent:8080" {
+		t.Errorf("SessionsTargetURL = %q, want backend (opted out)", got)
+	}
+	if got := cfg.FeedbackTargetURL(); got != "http://platform:8080" {
+		t.Errorf("FeedbackTargetURL = %q, want platform (still opted in)", got)
+	}
+	if got := cfg.TracesTargetURL(); got != "http://platform:8080" {
+		t.Errorf("TracesTargetURL = %q, want platform (still opted in)", got)
+	}
+}
+
+func TestLoad_PlatformURL_TrailingSlashTrimmed(t *testing.T) {
+	cfg, err := loadWithEnv(t, map[string]string{
+		"BACKEND_URL":          "http://agent:8080",
+		"GATEWAY_PLATFORM_URL": "http://platform:8080/",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PlatformURL != "http://platform:8080" {
+		t.Errorf("PlatformURL = %q, want trailing slash trimmed", cfg.PlatformURL)
+	}
+}
+
+func TestLoad_PlatformToggle_NoOpWhenURLUnset(t *testing.T) {
+	cfg, err := loadWithEnv(t, map[string]string{
+		"BACKEND_URL":                     "http://agent:8080",
+		"GATEWAY_PLATFORM_ROUTE_SESSIONS": "true",
+		"GATEWAY_PLATFORM_ROUTE_TRACES":   "true",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Toggles set without PLATFORM_URL must still resolve to backend —
+	// they're cheap config knobs, not failure modes.
+	if got := cfg.SessionsTargetURL(); got != "http://agent:8080" {
+		t.Errorf("SessionsTargetURL = %q, want backend (URL unset)", got)
+	}
+}
+
 func TestLoad_JWTExchange_NotConsultedInAnonymousMode(t *testing.T) {
 	// Setting exchange env vars while in anonymous mode should not trigger
 	// the partial-config validator. They're inert outside jwt mode, so

--- a/internal/handler/forward.go
+++ b/internal/handler/forward.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// ForwardingHandler is a thin reverse-proxy handler that forwards every
+// inbound request under a path prefix to a target base URL verbatim. It
+// preserves the request method, body, query string, and headers (subject
+// to standard hop-by-hop stripping that net/http/httputil.ReverseProxy
+// performs automatically).
+//
+// Used to proxy /v1/feedback*, /v1/sessions/*, and /v1/traces/* to a
+// deployed fipsagents-platform service when the gateway is configured
+// with a non-empty PLATFORM_URL. The auth middleware runs before the
+// proxy fires, so the Authorization, X-Auth-*, and X-Tenant headers it
+// projects are forwarded to the platform unchanged. The W3C Trace
+// Context traceparent header is also end-to-end and forwarded as-is.
+//
+// The handler does not interpret request bodies — every prefix is
+// proxied as opaque bytes, matching the issue's "no payload
+// interpretation" contract.
+type ForwardingHandler struct {
+	// TargetURL is the base URL that requests are forwarded to (eg
+	// "http://fipsagents-platform.svc:8080"). Trailing slashes are
+	// trimmed by the config layer. The inbound request path is
+	// appended as-is.
+	TargetURL string
+
+	// Logger receives forwarding events. When nil, slog.Default() is
+	// used.
+	Logger *slog.Logger
+
+	proxy *httputil.ReverseProxy
+}
+
+// New returns a ForwardingHandler whose underlying ReverseProxy is wired
+// up against TargetURL. Returns an error if TargetURL is empty or not a
+// parseable URL.
+func NewForwardingHandler(targetURL string) (*ForwardingHandler, error) {
+	target, err := url.Parse(strings.TrimRight(targetURL, "/"))
+	if err != nil {
+		return nil, err
+	}
+	h := &ForwardingHandler{TargetURL: target.String()}
+	h.proxy = &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			// Preserve the inbound path + query verbatim; only the
+			// scheme + host change.
+			pr.Out.URL.Scheme = target.Scheme
+			pr.Out.URL.Host = target.Host
+			// Some platform deployments live under a path prefix
+			// (eg /platform). Honor TargetURL.Path as a base.
+			pr.Out.URL.Path = singleJoiningSlash(target.Path, pr.In.URL.Path)
+			pr.Out.URL.RawPath = ""
+			pr.Out.Host = target.Host
+			// Preserve client headers (Authorization, X-Auth-*,
+			// X-Tenant, traceparent). httputil strips hop-by-hop
+			// automatically.
+			pr.Out.Header = pr.In.Header.Clone()
+			// Drop any inbound Host header echo so the upstream
+			// sees the platform host.
+			pr.Out.Header.Del("Host")
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			logger := h.Logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Error("platform proxy failed",
+				"error", err,
+				"target", target.String(),
+				"path", r.URL.Path,
+				"method", r.Method,
+			)
+			http.Error(w, `{"error":"platform unreachable"}`, http.StatusBadGateway)
+		},
+	}
+	return h, nil
+}
+
+func (h *ForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.proxy.ServeHTTP(w, r)
+}
+
+// singleJoiningSlash concatenates two URL path components ensuring
+// exactly one slash between them. Mirrors the helper in stdlib's
+// httputil but is unexported there. Empty target prefix is the common
+// case (TargetURL has no path); this still works.
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash && a != "" && b != "":
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/internal/handler/forward_test.go
+++ b/internal/handler/forward_test.go
@@ -1,0 +1,198 @@
+package handler_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/fips-agents/gateway-template/internal/handler"
+)
+
+// recordedRequest captures everything ForwardingHandler-wired tests
+// commonly assert on without re-reading the http.Request after the
+// upstream has consumed the body.
+type recordedRequest struct {
+	mu      sync.Mutex
+	Method  string
+	Path    string
+	Query   string
+	Headers http.Header
+	Body    []byte
+}
+
+// newRecordingUpstream stands in for the platform service. It captures
+// the inbound request and replies with the configured status + body.
+func newRecordingUpstream(t *testing.T, status int, replyBody string) (*httptest.Server, *recordedRequest) {
+	t.Helper()
+	rec := &recordedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		rec.mu.Lock()
+		rec.Method = r.Method
+		rec.Path = r.URL.Path
+		rec.Query = r.URL.RawQuery
+		rec.Headers = r.Header.Clone()
+		rec.Body = body
+		rec.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, replyBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func TestForwardingHandler_PreservesPathAndQuery(t *testing.T) {
+	upstream, rec := newRecordingUpstream(t, 200, `{"ok":true}`)
+
+	h, err := handler.NewForwardingHandler(upstream.URL)
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/v1/sessions/abc/cost_data?include=true", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if rec.Path != "/v1/sessions/abc/cost_data" {
+		t.Errorf("upstream Path = %q, want /v1/sessions/abc/cost_data", rec.Path)
+	}
+	if rec.Query != "include=true" {
+		t.Errorf("upstream Query = %q, want include=true", rec.Query)
+	}
+}
+
+func TestForwardingHandler_ForwardsAuthHeaders(t *testing.T) {
+	upstream, rec := newRecordingUpstream(t, 200, `{}`)
+	h, err := handler.NewForwardingHandler(upstream.URL)
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/feedback", strings.NewReader(`{"rating":1}`))
+	req.Header.Set("Authorization", "Bearer swap-token")
+	req.Header.Set("X-Auth-Subject", "u-123")
+	req.Header.Set("X-Auth-User", "wes")
+	req.Header.Set("X-Auth-Email", "wes@example.com")
+	req.Header.Set("X-Tenant", "acme")
+	req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	want := map[string]string{
+		"Authorization":  "Bearer swap-token",
+		"X-Auth-Subject": "u-123",
+		"X-Auth-User":    "wes",
+		"X-Auth-Email":   "wes@example.com",
+		"X-Tenant":       "acme",
+		"Traceparent":    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+	}
+	for k, v := range want {
+		if got := rec.Headers.Get(k); got != v {
+			t.Errorf("upstream header %s = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestForwardingHandler_PreservesBodyAndMethod(t *testing.T) {
+	upstream, rec := newRecordingUpstream(t, 202, `{"id":"fb_42"}`)
+	h, err := handler.NewForwardingHandler(upstream.URL)
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	body := `{"comment":"thanks","rating":1}`
+	req := httptest.NewRequest("PATCH", "/v1/feedback/fb_42", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if rec.Method != "PATCH" {
+		t.Errorf("upstream method = %q, want PATCH", rec.Method)
+	}
+	if string(rec.Body) != body {
+		t.Errorf("upstream body = %q, want %q", string(rec.Body), body)
+	}
+	if w.Code != 202 {
+		t.Errorf("status = %d, want 202 (passthrough)", w.Code)
+	}
+	if got := w.Body.String(); got != `{"id":"fb_42"}` {
+		t.Errorf("response body = %q, want passthrough", got)
+	}
+}
+
+func TestForwardingHandler_HEADRequestSupported(t *testing.T) {
+	// HttpSessionStore.exists() uses HEAD. The proxy must forward it
+	// without choking on the empty body.
+	upstream, rec := newRecordingUpstream(t, 200, "")
+	h, err := handler.NewForwardingHandler(upstream.URL)
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	req := httptest.NewRequest("HEAD", "/v1/sessions/s-1", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if rec.Method != "HEAD" {
+		t.Errorf("upstream method = %q, want HEAD", rec.Method)
+	}
+	if w.Code != 200 {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestForwardingHandler_UpstreamUnreachable(t *testing.T) {
+	// Build a handler against a closed upstream — connect should fail.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // close before any request
+	h, err := handler.NewForwardingHandler(srv.URL)
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/v1/traces", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 BadGateway on upstream failure", w.Code)
+	}
+}
+
+func TestForwardingHandler_TargetWithBasePath(t *testing.T) {
+	// Some platform deployments live under a sub-path (eg /platform).
+	// Inbound paths should land under the base.
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(204)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, err := handler.NewForwardingHandler(srv.URL + "/platform")
+	if err != nil {
+		t.Fatalf("NewForwardingHandler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/v1/sessions/s-1", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if gotPath != "/platform/v1/sessions/s-1" {
+		t.Errorf("upstream Path = %q, want /platform prefix preserved", gotPath)
+	}
+}
+
+func TestNewForwardingHandler_RejectsBadURL(t *testing.T) {
+	if _, err := handler.NewForwardingHandler("://bad-url"); err == nil {
+		t.Error("expected error on malformed URL, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Opt-in routing mode: when `GATEWAY_PLATFORM_URL` is set, `/v1/feedback*`, `/v1/sessions/*`, and `/v1/traces/*` proxy directly to a deployed [`fipsagents-platform`](https://github.com/fips-agents/fipsagents-platform) service.
- Per-prefix opt-out toggles (`platform.feedback|sessions|traces`) so deployments can mix backends.
- `GET /v1/sessions/{id}/usage` is always agent-routed (USD cost is computed in-process from `PricingConfig`).
- Backward-compatible: when `PLATFORM_URL` is unset, fan-out behavior matches 0.4.x exactly. Existing test suite passes unmodified.

## Why

Implementation companion to fips-agents/agent-template#112 (architecture decision). Pairs with the agent-side `HttpSessionStore` / `HttpTraceStore` / `HttpFeedbackStore` work in agent-template#114 / #115. With both ends in place, multi-agent deployments can centralize persistence and observability through one platform service rather than fanning queries across N agent backends.

## Implementation

- **Config** (`internal/config/config.go`): `PlatformURL` + three per-prefix booleans, default `true` when URL set. Helper methods `FeedbackTargetURL()`, `SessionsTargetURL()`, `TracesTargetURL()` collapse the routing decision to one place. Trailing slashes trimmed at load.
- **Handler** (`internal/handler/forward.go`): `ForwardingHandler` is a thin `httputil.ReverseProxy` wrapper. No payload interpretation — method, body, query string, `Authorization` (post-RFC-8693 swap), `X-Auth-*`, `X-Tenant`, and `traceparent` all forwarded verbatim. Hop-by-hop stripping delegated to stdlib. Targets with a base path (eg `http://platform/api`) are honored.
- **Wiring** (`cmd/server/main.go`): existing feedback handlers re-target via `cfg.FeedbackTargetURL()` (no behavior change at default config). New `/v1/sessions/` + `/v1/traces/` routes registered. The `/usage` carve-out wins via Go 1.22 mux specificity rules.
- **Chart** (0.4.0 → 0.5.0): new `platform:` block in `values.yaml`, configmap conditionally emits `GATEWAY_PLATFORM_*` env vars when `platform.url` is set.
- **Docs**: CLAUDE.md routing diagram + env var table updated.

## Tests

13 new tests, all passing. Existing suite unmodified, all green.

- **Config (5)**: `PLATFORM_URL` unset → fan-out; set → all three routed; per-prefix opt-out; trailing slash trimmed; toggles inert without `URL`.
- **Handler (8)**: path + query preservation, auth header forwarding (incl. traceparent), POST/PATCH/HEAD passthrough, body byte-for-byte, 502 on upstream unreachable, base-path target honored, malformed URL rejected at construction.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `helm template` with and without `platform.url` — emits expected configmap
- [x] `gitleaks dir` — no secrets

## Companion work

- fips-agents/agent-template#114 — HTTP store implementations on the agent side (already merged, in `fipsagents>=0.13.0`)
- fips-agents/agent-template#115 — `HttpSessionStore.get_cost_data` cumulative read (in `fipsagents>=0.14.2`)
- Cost Tracking v2 (`fipsagents>=0.15.0`) — adds `/v1/sessions/{id}/usage` on the agent (always agent-routed by this PR)