### PR TITLE
feat: Streaming multipart file upload proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ Client --> Gateway (:8080) --> Backend Agent
              +-- /v1/sessions/*        (any method, opaque proxy; routable to platform)
              +-- /v1/sessions/{id}/usage (GET, agent-only — pricing computed in-process)
              +-- /v1/traces/*          (any method, opaque proxy; routable to platform)
+             +-- /v1/files             (POST streaming multipart proxy; size cap + MIME allowlist)
+             +-- /v1/files             (GET pass-through, list)
+             +-- /v1/files/{file_id}   (GET/DELETE pass-through)
              +-- /v1/agent-info        (GET, pass-through to backend)
              +-- /healthz              (GET, liveness)
              +-- /readyz               (GET, checks backend)
@@ -81,6 +84,20 @@ Key packages:
 | `GATEWAY_PLATFORM_ROUTE_FEEDBACK` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/feedback*` to platform. Set `false` to keep on agent. No-op when `PLATFORM_URL` unset. |
 | `GATEWAY_PLATFORM_ROUTE_SESSIONS` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/sessions/*` to platform (except `/usage`, always agent). Set `false` to keep on agent. |
 | `GATEWAY_PLATFORM_ROUTE_TRACES` | No | `true` (when `PLATFORM_URL` set) | Route `/v1/traces/*` to platform. Set `false` to keep on agent. |
+| `GATEWAY_FILES_MAX_BYTES` | No | `26214400` (25 MiB) | Cap on multipart upload size. Accepts plain integers or values suffixed with `k`/`m`/`g` (binary). Requests over this size are rejected with 413 before the body is read; chunked clients are interrupted by `http.MaxBytesReader`. |
+| `GATEWAY_FILES_ALLOWED_MIME` | No | -- | Comma-separated MIME allowlist for the file part of `/v1/files` uploads. Entries may be exact (`application/pdf`) or wildcard (`image/*`). Empty defers entirely to the agent's own allowlist. |
+| `GATEWAY_FILES_UPLOAD_TIMEOUT` | No | `5m` | Per-request timeout for backend `POST /v1/files` calls. Larger than the chat-completion timeout so big uploads on slow links don't trip the gateway-side deadline before the agent finishes parsing. |
+
+## File upload proxy
+
+`POST /v1/files` is a streaming multipart proxy. The handler enforces two checks before forwarding:
+
+- **Size cap.** If the inbound `Content-Length` exceeds `GATEWAY_FILES_MAX_BYTES`, the gateway returns 413 immediately. For chunked or missing-`Content-Length` requests, an `http.MaxBytesReader` interrupts the body once the cap is hit.
+- **MIME allowlist.** The first multipart file part's declared `Content-Type` is validated synchronously against `GATEWAY_FILES_ALLOWED_MIME` *before* the upstream request fires. Disallowed types return 415 without ever contacting the backend. The agent runs its own libmagic-based content sniffing in `agent-template/packages/fipsagents/src/fipsagents/server/files.py` — gateway validation is defense in depth, not the authoritative gate.
+
+The body itself is never buffered: the handler reads the inbound multipart, re-encodes parts via `mime/multipart.Writer`, and pipes them into the upstream request body. Form fields encountered before the file part (eg `session_id`) are read into memory because they're tiny by spec; file part bodies stream through `io.Copy`.
+
+`GET /v1/files`, `GET /v1/files/{file_id}`, and `DELETE /v1/files/{file_id}` are opaque pass-throughs handled by the same `httputil.ReverseProxy` used for sessions/traces. Files are always agent-routed — there is no platform-side `/v1/files` surface today.
 
 ## Auth contract
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ curl http://localhost:8080/healthz
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) client secret for the exchange request |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE` | exchange | -- | (`jwt` mode) downstream audience the swapped token is issued for |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE` | No | -- | (`jwt` mode) optional space-separated scope set requested on the swap |
+| `GATEWAY_FILES_MAX_BYTES` | No | `26214400` (25 MiB) | Max accepted size for `POST /v1/files`. Plain bytes or `k`/`m`/`g` suffix (binary). |
+| `GATEWAY_FILES_ALLOWED_MIME` | No | -- | Comma-separated MIME allowlist for `POST /v1/files`. Exact (`application/pdf`) or wildcard (`image/*`). Empty defers to the agent. |
+| `GATEWAY_FILES_UPLOAD_TIMEOUT` | No | `5m` | Per-request timeout for backend `POST /v1/files`. |
+
+## File uploads
+
+`POST /v1/files` is proxied to the agent as a streaming multipart upload. Two checks run before any byte reaches the agent:
+
+- **Size cap** — `GATEWAY_FILES_MAX_BYTES`. Inbound `Content-Length` over the cap returns 413 immediately. Chunked or unsigned-length bodies are interrupted by `http.MaxBytesReader`.
+- **MIME allowlist** — `GATEWAY_FILES_ALLOWED_MIME` (comma-separated, supports `image/*` wildcards). The first multipart file part's declared `Content-Type` is validated *before* the upstream request fires; rejections return 415 without contacting the backend.
+
+The body is never buffered: form fields (e.g. `session_id`) are read into memory because they're tiny by spec, but the file part body is `io.Copy`'d into a re-encoded multipart that streams through a pipe to the backend. Defense in depth on top of the agent's own libmagic-based content sniffing — not a replacement.
+
+`GET /v1/files`, `GET /v1/files/{file_id}`, and `DELETE /v1/files/{file_id}` are opaque pass-throughs to the agent.
 
 ## Authentication
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 description: Go HTTP gateway for AI agents

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -19,6 +19,17 @@ data:
   GATEWAY_PLATFORM_ROUTE_TRACES: {{ .traces | default false | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.files }}
+  {{- if .maxBytes }}
+  GATEWAY_FILES_MAX_BYTES: {{ .maxBytes | quote }}
+  {{- end }}
+  {{- if .allowedMime }}
+  GATEWAY_FILES_ALLOWED_MIME: {{ .allowedMime | quote }}
+  {{- end }}
+  {{- if .uploadTimeout }}
+  GATEWAY_FILES_UPLOAD_TIMEOUT: {{ .uploadTimeout | quote }}
+  {{- end }}
+  {{- end }}
   {{- if eq .Values.auth.mode "jwt" }}
   GATEWAY_AUTH_JWT_JWKS_URL: {{ required "auth.jwt.jwksUrl is required when auth.mode=jwt" .Values.auth.jwt.jwksUrl | quote }}
   GATEWAY_AUTH_JWT_ISSUER: {{ required "auth.jwt.issuer is required when auth.mode=jwt" .Values.auth.jwt.issuer | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -103,6 +103,27 @@ platform:
   sessions: true
   traces: true
 
+# -- File upload proxy (gateway-template#11) ---------------------------------
+# /v1/files multipart uploads stream through the gateway with a size cap and
+# a MIME-type allowlist enforced before any bytes reach the agent. The
+# allowlist may include wildcards (eg "image/*"); leaving it empty allows
+# every type that the agent itself accepts (the agent runs libmagic-based
+# content sniffing on its own and is the authoritative gate).
+files:
+  # Maximum upload size accepted by the gateway. Accepts a plain integer
+  # (bytes) or a value suffixed with k/m/g (binary). Requests advertising
+  # a Content-Length over this value are rejected with 413 before the
+  # body is read; chunked clients are interrupted by an http.MaxBytesReader.
+  maxBytes: "25m"
+  # Comma-separated MIME-type allowlist. Entries may be exact
+  # ("application/pdf") or wildcard ("image/*"). Leave empty to defer to
+  # the agent's own allowlist.
+  allowedMime: ""
+  # Per-request timeout for backend POST /v1/files calls. Larger than the
+  # gateway's default 120s so big uploads on slow links don't trip the
+  # gateway-side deadline before the agent finishes parsing.
+  uploadTimeout: "5m"
+
 service:
   port: 8080
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,6 +105,26 @@ func main() {
 	mux.Handle("GET /v1/sessions/{session_id}/usage", usageForward)
 	mux.Handle("/v1/sessions/", sessionsForward)
 	mux.Handle("/v1/traces/", tracesForward)
+
+	// /v1/files: streaming multipart proxy on POST, opaque pass-through
+	// on GET/DELETE. The upload path enforces a size cap and MIME
+	// allowlist before forwarding; metadata operations don't need
+	// special handling. Files are always agent-routed (no platform
+	// equivalent today; see agent-template#100).
+	filesForward, err := handler.NewForwardingHandler(cfg.BackendURL)
+	if err != nil {
+		slog.Error("files forward configuration error", "error", err)
+		os.Exit(1)
+	}
+	mux.Handle("POST /v1/files", &handler.FilesUploadHandler{
+		BackendURL: cfg.BackendURL,
+		MaxBytes:   cfg.FilesMaxBytes,
+		Cfg:        cfg,
+		Timeout:    cfg.FilesUploadTimeout,
+		Client:     &http.Client{},
+	})
+	mux.Handle("GET /v1/files", filesForward)
+	mux.Handle("/v1/files/", filesForward)
 	mux.Handle("/healthz", &handler.HealthHandler{})
 	mux.Handle("/readyz", &handler.ReadyHandler{
 		BackendURL: cfg.BackendURL,
@@ -156,6 +176,9 @@ func main() {
 			"version", cfg.AgentVersion,
 			"auth_mode", cfg.AuthMode,
 			"jwt_token_exchange", exchanger != nil,
+			"files_max_bytes", cfg.FilesMaxBytes,
+			"files_upload_timeout", cfg.FilesUploadTimeout,
+			"files_allowed_mime_count", len(cfg.FilesAllowedMIME),
 		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,21 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 )
+
+// FilesMaxBytesDefault is the default cap on multipart upload size (25
+// MiB). Sized to comfortably fit reference docs (PDFs, code archives)
+// while staying well clear of typical reverse-proxy buffer limits. Raise
+// via GATEWAY_FILES_MAX_BYTES for deployments that ingest large media.
+const FilesMaxBytesDefault int64 = 25 * 1024 * 1024
+
+// FilesUploadTimeoutDefault is the default per-request deadline applied
+// to backend POST /v1/files calls. Larger than the gateway's default 120s
+// to accommodate slow links uploading near the size cap.
+const FilesUploadTimeoutDefault = 5 * time.Minute
 
 // Config holds the gateway configuration loaded from environment variables.
 type Config struct {
@@ -63,6 +76,56 @@ type Config struct {
 	PlatformRouteFeedback bool
 	PlatformRouteSessions bool
 	PlatformRouteTraces   bool
+
+	// FilesMaxBytes caps the size of a single multipart upload at the
+	// gateway. Requests advertising a Content-Length over this limit are
+	// rejected with 413 before any bytes are read. Streamed bodies are
+	// counted with http.MaxBytesReader so chunked clients cannot bypass
+	// the check by omitting Content-Length. Default: 25 MiB.
+	FilesMaxBytes int64
+
+	// FilesAllowedMIME is the gateway-level MIME allowlist applied to
+	// each file part of a multipart upload. Entries may be exact
+	// (eg "application/pdf") or wildcard (eg "image/*"); empty means
+	// allow-all (the agent's own allowlist still applies). Parsed from
+	// the comma-separated GATEWAY_FILES_ALLOWED_MIME variable.
+	FilesAllowedMIME []string
+
+	// FilesUploadTimeout is the per-request timeout applied to backend
+	// POST /v1/files calls. Default: 5 minutes (vs the 120s used for
+	// chat completions) so large uploads on slow links don't trip the
+	// gateway-side deadline before the agent finishes parsing.
+	FilesUploadTimeout time.Duration
+}
+
+// MIMEAllowed reports whether contentType matches the FilesAllowedMIME
+// allowlist. An empty allowlist means allow-all. Each list entry may be
+// an exact type ("application/pdf") or a wildcard ("image/*"); the
+// match is case-insensitive on the type/subtype but ignores any
+// boundary parameter the caller might have appended.
+func (c *Config) MIMEAllowed(contentType string) bool {
+	if len(c.FilesAllowedMIME) == 0 {
+		return true
+	}
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	if ct == "" {
+		return false
+	}
+	for _, allowed := range c.FilesAllowedMIME {
+		if allowed == ct {
+			return true
+		}
+		if strings.HasSuffix(allowed, "/*") {
+			prefix := allowed[:len(allowed)-1] // keep trailing slash
+			if strings.HasPrefix(ct, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // FeedbackTargetURL returns the base URL that /v1/feedback* requests
@@ -135,6 +198,18 @@ func Load() (*Config, error) {
 		PlatformRouteTraces:   envBoolDefault("GATEWAY_PLATFORM_ROUTE_TRACES", true),
 	}
 
+	maxBytes, err := envBytesDefault("GATEWAY_FILES_MAX_BYTES", FilesMaxBytesDefault)
+	if err != nil {
+		return nil, err
+	}
+	cfg.FilesMaxBytes = maxBytes
+	cfg.FilesAllowedMIME = parseMIMEList(os.Getenv("GATEWAY_FILES_ALLOWED_MIME"))
+	timeout, err := envDurationDefault("GATEWAY_FILES_UPLOAD_TIMEOUT", FilesUploadTimeoutDefault)
+	if err != nil {
+		return nil, err
+	}
+	cfg.FilesUploadTimeout = timeout
+
 	if cfg.BackendURL == "" {
 		return nil, fmt.Errorf("BACKEND_URL environment variable is required")
 	}
@@ -205,4 +280,73 @@ func envBoolDefault(key string, fallback bool) bool {
 	}
 	v := strings.ToLower(raw)
 	return v == "true" || v == "1" || v == "yes"
+}
+
+// envBytesDefault parses a byte-count env var. Accepts plain integers
+// (bytes) or values suffixed with k/m/g (binary, case-insensitive: 5MiB
+// counts as the same thing as 5m). Returns the fallback when the
+// variable is unset or empty.
+func envBytesDefault(key string, fallback int64) (int64, error) {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback, nil
+	}
+	s := strings.TrimSpace(strings.ToLower(raw))
+	mult := int64(1)
+	for _, suf := range []struct {
+		s string
+		m int64
+	}{
+		{"gib", 1 << 30}, {"gb", 1 << 30}, {"g", 1 << 30},
+		{"mib", 1 << 20}, {"mb", 1 << 20}, {"m", 1 << 20},
+		{"kib", 1 << 10}, {"kb", 1 << 10}, {"k", 1 << 10},
+	} {
+		if strings.HasSuffix(s, suf.s) {
+			mult = suf.m
+			s = strings.TrimSuffix(s, suf.s)
+			break
+		}
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid byte count %q: %w", key, raw, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("%s: must be positive, got %q", key, raw)
+	}
+	return n * mult, nil
+}
+
+// envDurationDefault parses a Go duration string from an env var.
+func envDurationDefault(key string, fallback time.Duration) (time.Duration, error) {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback, nil
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid duration %q: %w", key, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s: must be positive, got %q", key, raw)
+	}
+	return d, nil
+}
+
+// parseMIMEList splits a comma-separated MIME-type list, trimming
+// whitespace and dropping empty entries. Lowercased so the runtime
+// matcher can compare without re-normalising.
+func parseMIMEList(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := strings.ToLower(strings.TrimSpace(p))
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/internal/handler/files.go
+++ b/internal/handler/files.go
@@ -1,0 +1,324 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+
+	"github.com/fips-agents/gateway-template/internal/config"
+)
+
+// FilesUploadHandler proxies POST /v1/files multipart uploads to the
+// backend agent, enforcing a size cap and a MIME-type allowlist before
+// any bytes leave the gateway. The proxy is streaming: the file body
+// is piped chunk-by-chunk into a fresh multipart writer wrapping a
+// pipe that feeds the upstream request, never buffered whole.
+//
+// The size cap is enforced two ways: an immediate 413 when the inbound
+// Content-Length exceeds MaxBytes, and a wrapping http.MaxBytesReader
+// that interrupts mid-stream uploads (chunked transfers, missing
+// Content-Length) once the limit is reached.
+//
+// MIME validation runs on each "file" part's declared Content-Type.
+// The first file part is validated synchronously — failing fast with
+// 415 before any upstream request fires. Subsequent file parts (rare
+// in practice; the agent contract is single-file-per-request) are
+// validated as they're encountered. The agent does its own libmagic
+// content sniffing — gateway validation is defense in depth against
+// obviously-misclassified uploads.
+type FilesUploadHandler struct {
+	BackendURL string
+	MaxBytes   int64
+	Cfg        *config.Config
+	Timeout    time.Duration
+	// Client is the HTTP client used for the upstream request. The
+	// caller owns the timeout via Timeout — Client.Timeout is ignored
+	// so it can be shared with other handlers.
+	Client *http.Client
+}
+
+// ServeHTTP enforces method, size, and MIME constraints, then streams
+// the multipart upload to the backend's /v1/files endpoint with the
+// canonical X-Auth-* headers preserved.
+func (h *FilesUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "multipart/form-data") {
+		http.Error(w, `{"error":"Content-Type must be multipart/form-data"}`, http.StatusUnsupportedMediaType)
+		return
+	}
+	if params["boundary"] == "" {
+		http.Error(w, `{"error":"multipart boundary missing"}`, http.StatusBadRequest)
+		return
+	}
+
+	if r.ContentLength > 0 && h.MaxBytes > 0 && r.ContentLength > h.MaxBytes {
+		http.Error(w, fmt.Sprintf(
+			`{"error":"upload exceeds max size","max_bytes":%d}`, h.MaxBytes,
+		), http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	body := r.Body
+	if h.MaxBytes > 0 {
+		body = http.MaxBytesReader(w, body, h.MaxBytes)
+	}
+	defer body.Close()
+
+	mr := multipart.NewReader(body, params["boundary"])
+
+	// Walk parts synchronously up to and including the first file
+	// part. Form fields encountered along the way are buffered (they
+	// are small by spec — session_id, etc.). The first file part's
+	// header is validated before we commit to any upstream request.
+	prefix, firstFile, err := h.collectPrefix(mr)
+	if err != nil {
+		var ve *validationError
+		if errors.As(err, &ve) {
+			http.Error(w, ve.body, ve.status)
+			return
+		}
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			http.Error(w, fmt.Sprintf(
+				`{"error":"upload exceeds max size","max_bytes":%d}`, h.MaxBytes,
+			), http.StatusRequestEntityTooLarge)
+			return
+		}
+		slog.Warn("multipart prefix parse failed", "error", err)
+		http.Error(w, `{"error":"invalid multipart body"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Pipe the re-encoded multipart body to the backend. The pipe
+	// lets us start the upstream request as soon as the first byte
+	// is ready and surfaces any read error from the inbound side as
+	// a write error on the upstream side.
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+
+	go func() {
+		defer pw.Close()
+		err := h.streamRest(mr, mw, prefix, firstFile)
+		if err != nil {
+			_ = mw.Close()
+			pw.CloseWithError(err)
+			return
+		}
+		if err := mw.Close(); err != nil {
+			pw.CloseWithError(err)
+		}
+	}()
+
+	ctx := r.Context()
+	if h.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, h.Timeout)
+		defer cancel()
+	}
+
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, h.BackendURL+"/v1/files", pr)
+	if err != nil {
+		slog.Error("failed to build upstream request", "error", err)
+		http.Error(w, `{"error":"failed to build backend request"}`, http.StatusInternalServerError)
+		return
+	}
+	upstream.Header.Set("Content-Type", mw.FormDataContentType())
+	for _, name := range forwardedAuthHeaders {
+		if v := r.Header.Get(name); v != "" {
+			upstream.Header.Set(name, v)
+		}
+	}
+
+	resp, err := h.Client.Do(upstream)
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			http.Error(w, fmt.Sprintf(
+				`{"error":"upload exceeds max size","max_bytes":%d}`, h.MaxBytes,
+			), http.StatusRequestEntityTooLarge)
+			return
+		}
+		var ve *validationError
+		if errors.As(err, &ve) {
+			http.Error(w, ve.body, ve.status)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			http.Error(w, `{"error":"upload timed out"}`, http.StatusGatewayTimeout)
+			return
+		}
+		slog.Error("backend upload failed", "error", err)
+		http.Error(w, `{"error":"backend request failed"}`, http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	copyPassThroughHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		slog.Warn("error copying backend response", "error", err)
+	}
+}
+
+// bufferedField is a non-file multipart part read into memory so it can
+// be replayed to the upstream writer after the file part's MIME has
+// been validated. Form fields in the agent contract are small
+// (session_id is at most 128 chars), so memory is bounded.
+type bufferedField struct {
+	header textproto.MIMEHeader
+	body   []byte
+}
+
+// collectPrefix walks mr until it has either encountered the first
+// file part (whose header passes MIME validation) or exhausted the
+// multipart body. Non-file form fields encountered along the way are
+// fully read into memory and returned as the prefix to be replayed by
+// the streaming goroutine. Returns the open file part for streaming;
+// firstFile may be nil if the upload contained no file parts (rare —
+// surfaced as a 400 by the caller).
+func (h *FilesUploadHandler) collectPrefix(mr *multipart.Reader) ([]bufferedField, *multipart.Part, error) {
+	var prefix []bufferedField
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			return prefix, nil, &validationError{
+				status: http.StatusBadRequest,
+				body:   `{"error":"multipart body has no file part"}`,
+			}
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		if part.FileName() == "" {
+			data, err := io.ReadAll(part)
+			_ = part.Close()
+			if err != nil {
+				return nil, nil, err
+			}
+			prefix = append(prefix, bufferedField{
+				header: cloneHeader(part.Header),
+				body:   data,
+			})
+			continue
+		}
+		ct := part.Header.Get("Content-Type")
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		if !h.Cfg.MIMEAllowed(ct) {
+			_ = part.Close()
+			return nil, nil, &validationError{
+				status: http.StatusUnsupportedMediaType,
+				body: fmt.Sprintf(
+					`{"error":"MIME type not allowed","content_type":%q}`, ct,
+				),
+			}
+		}
+		return prefix, part, nil
+	}
+}
+
+// streamRest writes the buffered form fields, then the file part body
+// (streamed via io.Copy), then walks any remaining parts and forwards
+// them. Any subsequent file part with a disallowed MIME closes the
+// pipe with a validationError so the upstream HTTP client returns it
+// to the main handler.
+func (h *FilesUploadHandler) streamRest(
+	mr *multipart.Reader,
+	mw *multipart.Writer,
+	prefix []bufferedField,
+	firstFile *multipart.Part,
+) error {
+	for _, f := range prefix {
+		out, err := mw.CreatePart(f.header)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(f.body); err != nil {
+			return err
+		}
+	}
+	if firstFile != nil {
+		if err := copyPart(mw, firstFile); err != nil {
+			return err
+		}
+	}
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if part.FileName() != "" {
+			ct := part.Header.Get("Content-Type")
+			if ct == "" {
+				ct = "application/octet-stream"
+			}
+			if !h.Cfg.MIMEAllowed(ct) {
+				_ = part.Close()
+				return &validationError{
+					status: http.StatusUnsupportedMediaType,
+					body: fmt.Sprintf(
+						`{"error":"MIME type not allowed","content_type":%q}`, ct,
+					),
+				}
+			}
+		}
+		if err := copyPart(mw, part); err != nil {
+			return err
+		}
+	}
+}
+
+func copyPart(mw *multipart.Writer, part *multipart.Part) error {
+	out, err := mw.CreatePart(part.Header)
+	if err != nil {
+		_ = part.Close()
+		return err
+	}
+	if _, err := io.Copy(out, part); err != nil {
+		_ = part.Close()
+		return err
+	}
+	return part.Close()
+}
+
+func cloneHeader(h textproto.MIMEHeader) textproto.MIMEHeader {
+	out := make(textproto.MIMEHeader, len(h))
+	for k, v := range h {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// validationError carries an HTTP status and a JSON body string so a
+// failure inside the streaming goroutine can be mapped back to a
+// precise client response from ServeHTTP.
+type validationError struct {
+	status int
+	body   string
+}
+
+func (e *validationError) Error() string {
+	return fmt.Sprintf("validation: status=%d body=%s", e.status, e.body)
+}

--- a/internal/handler/files_test.go
+++ b/internal/handler/files_test.go
@@ -1,0 +1,341 @@
+package handler_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fips-agents/gateway-template/internal/config"
+	"github.com/fips-agents/gateway-template/internal/handler"
+)
+
+// buildMultipart builds a multipart/form-data body containing one file
+// part with the given filename, declared Content-Type, and payload, plus
+// any extra form fields. Returns the body, the boundary, and the byte
+// length so callers can set Content-Length.
+func buildMultipart(t *testing.T, filename, contentType string, payload []byte, fields map[string]string) (*bytes.Buffer, string, int) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	mw := multipart.NewWriter(buf)
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField: %v", err)
+		}
+	}
+	hdr := textproto.MIMEHeader{}
+	hdr.Set("Content-Disposition", fmt.Sprintf(`form-data; name=%q; filename=%q`, "file", filename))
+	hdr.Set("Content-Type", contentType)
+	part, err := mw.CreatePart(hdr)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := part.Write(payload); err != nil {
+		t.Fatalf("part.Write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("mw.Close: %v", err)
+	}
+	return buf, mw.Boundary(), buf.Len()
+}
+
+// newFilesHandler wires a FilesUploadHandler against a backend test
+// server with the given gateway config overrides.
+func newFilesHandler(backendURL string, cfg *config.Config) *handler.FilesUploadHandler {
+	return &handler.FilesUploadHandler{
+		BackendURL: backendURL,
+		MaxBytes:   cfg.FilesMaxBytes,
+		Cfg:        cfg,
+		Timeout:    cfg.FilesUploadTimeout,
+		Client:     &http.Client{},
+	}
+}
+
+func TestFilesUpload_HappyPath(t *testing.T) {
+	var receivedBody []byte
+	var receivedCT string
+	var receivedSubject, receivedAuthorization string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/files" {
+			t.Errorf("backend path = %q, want /v1/files", r.URL.Path)
+		}
+		receivedCT = r.Header.Get("Content-Type")
+		receivedSubject = r.Header.Get("X-Auth-Subject")
+		receivedAuthorization = r.Header.Get("Authorization")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"file_id":"file_abc"}`))
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{
+		FilesMaxBytes:      1 << 20,
+		FilesUploadTimeout: 10 * time.Second,
+	}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "doc.pdf", "application/pdf", []byte("%PDF-1.4 hello"), map[string]string{"session_id": "s_42"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+	req.Header.Set("X-Auth-Subject", "alice")
+	req.Header.Set("Authorization", "Bearer swapped")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.HasPrefix(receivedCT, "multipart/form-data;") {
+		t.Errorf("backend Content-Type = %q, want multipart/form-data;...", receivedCT)
+	}
+	if receivedSubject != "alice" {
+		t.Errorf("X-Auth-Subject forwarded = %q, want alice", receivedSubject)
+	}
+	if receivedAuthorization != "Bearer swapped" {
+		t.Errorf("Authorization forwarded = %q, want swapped token", receivedAuthorization)
+	}
+	if !bytes.Contains(receivedBody, []byte("%PDF-1.4 hello")) {
+		t.Errorf("file payload not forwarded; body=%q", receivedBody)
+	}
+	if !bytes.Contains(receivedBody, []byte("s_42")) {
+		t.Errorf("session_id form field not forwarded; body=%q", receivedBody)
+	}
+}
+
+func TestFilesUpload_RejectsContentLengthOverCap(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("backend must not be reached when Content-Length exceeds cap")
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{FilesMaxBytes: 1024}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, _ := buildMultipart(t, "big.bin", "application/octet-stream", make([]byte, 4096), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	// Lie about Content-Length to force the early rejection path even
+	// though the body itself happens to also overflow.
+	req.ContentLength = 999_999
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "max_bytes") {
+		t.Errorf("body should include max_bytes hint: %s", rec.Body.String())
+	}
+}
+
+func TestFilesUpload_RejectsStreamingOverflow(t *testing.T) {
+	backendCalls := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+		// Drain so the pipe doesn't block; reply success even though the
+		// gateway should ultimately surface a 413 because MaxBytesReader
+		// will return an error mid-copy.
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{FilesMaxBytes: 256}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "big.bin", "application/octet-stream", bytes.Repeat([]byte("A"), 4096), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	// Match the inbound length so the early Content-Length check
+	// passes — must trip MaxBytesReader instead.
+	req.ContentLength = int64(length)
+	// Force chunked-style behavior: zero out Content-Length on the
+	// header, MaxBytesReader still enforces the cap.
+	req.Header.Del("Content-Length")
+	req.ContentLength = -1
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 (body=%s, backend_calls=%d)", rec.Code, rec.Body.String(), backendCalls)
+	}
+}
+
+func TestFilesUpload_RejectsDisallowedMIME(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("backend must not be reached when MIME is disallowed")
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{
+		FilesMaxBytes:    1 << 20,
+		FilesAllowedMIME: []string{"application/pdf", "image/*"},
+	}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "evil.exe", "application/x-msdownload", []byte("MZ"), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "x-msdownload") {
+		t.Errorf("body should mention rejected content_type, got %s", rec.Body.String())
+	}
+}
+
+func TestFilesUpload_AllowsWildcardMIME(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{
+		FilesMaxBytes:    1 << 20,
+		FilesAllowedMIME: []string{"application/pdf", "image/*"},
+	}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "pic.png", "image/png", []byte("\x89PNG"), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("wildcard match should pass: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFilesUpload_RejectsNonMultipart(t *testing.T) {
+	cfg := &config.Config{FilesMaxBytes: 1 << 20}
+	h := newFilesHandler("http://unreached", cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", strings.NewReader(`{"oops":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415", rec.Code)
+	}
+}
+
+func TestFilesUpload_MethodNotAllowed(t *testing.T) {
+	cfg := &config.Config{FilesMaxBytes: 1 << 20}
+	h := newFilesHandler("http://unreached", cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/files", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestFilesUpload_BackendErrorBecomes502(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and abort to simulate an unreachable upstream. Avoids
+		// the test-client being lenient about clean shutdowns.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("expected hijacker")
+		}
+		conn, _, _ := hj.Hijack()
+		_ = conn.Close()
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{FilesMaxBytes: 1 << 20, FilesUploadTimeout: 5 * time.Second}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "doc.pdf", "application/pdf", []byte("hi"), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+}
+
+func TestFilesUpload_TimeoutSurfaces504(t *testing.T) {
+	// Backend hangs forever — gateway timeout should fire and surface 504.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{FilesMaxBytes: 1 << 20, FilesUploadTimeout: 100 * time.Millisecond}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "doc.pdf", "application/pdf", []byte("hi"), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFilesUpload_NoCapWhenMaxBytesZero(t *testing.T) {
+	// MaxBytes == 0 means "no cap" — both the early Content-Length check
+	// and the wrapping reader are skipped.
+	backendHit := false
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendHit = true
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer backend.Close()
+
+	cfg := &config.Config{FilesMaxBytes: 0}
+	h := newFilesHandler(backend.URL, cfg)
+
+	body, boundary, length := buildMultipart(t, "huge.bin", "application/octet-stream", make([]byte, 4096), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.ContentLength = int64(length)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+	if !backendHit {
+		t.Error("backend should have been reached")
+	}
+}
+


### PR DESCRIPTION
## Summary

Closes #11. Adds `POST /v1/files` as a streaming multipart proxy and exposes the matching `GET`/`DELETE` surface as opaque pass-throughs.

## What's new

- **`POST /v1/files`** — a new `FilesUploadHandler` that streams multipart bodies through to the agent without buffering. Form fields are buffered (small by spec — `session_id` is at most 128 chars), but the file part's body is `io.Copy`'d into a re-encoded `multipart.Writer` that pipes into the upstream request body.
- **Size cap.** Two-layer enforcement: early 413 on `Content-Length` over `GATEWAY_FILES_MAX_BYTES`, plus `http.MaxBytesReader` to interrupt chunked or unsigned-length bodies mid-stream. Default 25 MiB; the env var accepts plain bytes or `k`/`m`/`g` suffixes.
- **MIME allowlist.** The first multipart file part's declared `Content-Type` is validated **synchronously**, before any upstream request fires — disallowed types return 415 without contacting the agent. Wildcards (`image/*`) supported. Defense in depth on top of the agent's libmagic-based content sniffing (`agent-template#100`, `server/files.py`); not a replacement.
- **Configurable upload timeout** — `GATEWAY_FILES_UPLOAD_TIMEOUT` defaults to 5m, longer than the gateway's general 120s default to give big uploads on slow links time to finish without tripping the gateway-side deadline before the agent finishes parsing.
- **`GET /v1/files`**, **`GET /v1/files/{id}`**, **`DELETE /v1/files/{id}`** — opaque pass-throughs using the existing `ForwardingHandler`. Files are always agent-routed (no platform `/v1/files` surface today).

## New configuration (all optional)

| Variable | Default | Notes |
|---|---|---|
| `GATEWAY_FILES_MAX_BYTES` | `26214400` (25 MiB) | Plain bytes or `k`/`m`/`g` suffix |
| `GATEWAY_FILES_ALLOWED_MIME` | -- | Comma-separated; supports `image/*` |
| `GATEWAY_FILES_UPLOAD_TIMEOUT` | `5m` | Backend `POST /v1/files` deadline |

Helm chart bumped to **0.6.0**. New `files` block in `values.yaml`; the ConfigMap emits the size cap and timeout under defaults and skips `GATEWAY_FILES_ALLOWED_MIME` when the allowlist is empty (empty defers entirely to the agent).

## Test plan

- [x] `make test` — full suite green (10 new tests in `internal/handler/files_test.go`, all passing)
- [x] `make lint` — clean
- [x] `helm template` renders cleanly with and without the new `files` block
- [x] `gitleaks` clean
- [ ] Smoke against a real agent with `[files]` extra installed — verify happy-path upload, 413 on oversized, 415 on disallowed MIME

## Test cases covered

`TestFilesUpload_HappyPath`, `TestFilesUpload_RejectsContentLengthOverCap`, `TestFilesUpload_RejectsStreamingOverflow` (chunked / no Content-Length), `TestFilesUpload_RejectsDisallowedMIME` (asserts backend never reached), `TestFilesUpload_AllowsWildcardMIME`, `TestFilesUpload_RejectsNonMultipart`, `TestFilesUpload_MethodNotAllowed`, `TestFilesUpload_BackendErrorBecomes502`, `TestFilesUpload_TimeoutSurfaces504`, `TestFilesUpload_NoCapWhenMaxBytesZero`.