### PR TITLE
auth: Configurable JWKS unknown-kid refresh rate limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Key packages:
 | `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim → `X-Auth-Subject` |
 | `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim → `X-Auth-User` |
 | `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim → `X-Auth-Email` |
+| `GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT` | No | -- | (`jwt` mode) Go duration capping how often the JWKS client refreshes in response to an unknown `kid`. Unset keeps keyfunc's default of 1 refresh per 5 minutes. Lower for faster post-rotation recovery; higher to harden against forged-kid bursts. |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL` | exchange | -- | (`jwt` mode) RFC 8693 token endpoint; setting all four required exchange vars enables the swap |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID` | exchange | -- | (`jwt` mode) gateway service-account client ID |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) gateway service-account client secret |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ curl http://localhost:8080/healthz
 | `GATEWAY_AUTH_JWT_SUBJECT_CLAIM` | No | `sub` | (`jwt` mode) claim to project onto `X-Auth-Subject` |
 | `GATEWAY_AUTH_JWT_USER_CLAIM` | No | `preferred_username` | (`jwt` mode) claim to project onto `X-Auth-User` |
 | `GATEWAY_AUTH_JWT_EMAIL_CLAIM` | No | `email` | (`jwt` mode) claim to project onto `X-Auth-Email` |
+| `GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT` | No | -- | (`jwt` mode) Go duration capping how often the JWKS client refreshes the key set when a token presents an unknown `kid`. Unset inherits keyfunc's library default (one refresh per 5 minutes). |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL` | exchange | -- | (`jwt` mode, optional) RFC 8693 token endpoint. Setting this together with the next three enables token exchange. |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID` | exchange | -- | (`jwt` mode) confidential client representing the gateway's service account on the exchange request |
 | `GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET` | exchange | -- | (`jwt` mode) client secret for the exchange request |

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -37,6 +37,9 @@ data:
   GATEWAY_AUTH_JWT_SUBJECT_CLAIM: {{ .Values.auth.jwt.subjectClaim | default "sub" | quote }}
   GATEWAY_AUTH_JWT_USER_CLAIM: {{ .Values.auth.jwt.userClaim | default "preferred_username" | quote }}
   GATEWAY_AUTH_JWT_EMAIL_CLAIM: {{ .Values.auth.jwt.emailClaim | default "email" | quote }}
+  {{- with .Values.auth.jwt.jwksRefreshRateLimit }}
+  GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT: {{ . | quote }}
+  {{- end }}
   {{- if .Values.auth.jwt.exchange.enabled }}
   GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_URL: {{ required "auth.jwt.exchange.tokenUrl is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.tokenUrl | quote }}
   GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_ID: {{ required "auth.jwt.exchange.clientId is required when auth.jwt.exchange.enabled=true" .Values.auth.jwt.exchange.clientId | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,6 +51,13 @@ auth:
     userClaim: preferred_username
     # Claim name to project onto X-Auth-Email. Default: email.
     emailClaim: email
+    # Cap how often the JWKS client refreshes the key set in response to
+    # an unknown `kid`. Empty / unset keeps keyfunc's library default of
+    # 1 refresh per 5 minutes — already conservative enough for most
+    # deployments. Set to a Go duration (eg "30s", "2m") only when you've
+    # measured a real post-rotation latency problem (lower) or want to
+    # harden against forged-kid bursts (higher). See gateway-template#28.
+    jwksRefreshRateLimit: ""
     # RFC 8693 token exchange (auth v2 part 2). When enabled, the gateway
     # swaps the inbound user JWT for a downstream-audienced token before
     # forwarding to the backend. The downstream MCP server / agent

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,12 +45,13 @@ func main() {
 		ProxyUserHeader:  cfg.AuthProxyUserHeader,
 		ProxyEmailHeader: cfg.AuthProxyEmailHeader,
 		JWT: auth.JWTConfig{
-			JWKSURL:      cfg.AuthJWTJWKSURL,
-			Issuer:       cfg.AuthJWTIssuer,
-			Audience:     cfg.AuthJWTAudience,
-			SubjectClaim: cfg.AuthJWTSubjectClaim,
-			UserClaim:    cfg.AuthJWTUserClaim,
-			EmailClaim:   cfg.AuthJWTEmailClaim,
+			JWKSURL:              cfg.AuthJWTJWKSURL,
+			Issuer:               cfg.AuthJWTIssuer,
+			Audience:             cfg.AuthJWTAudience,
+			SubjectClaim:         cfg.AuthJWTSubjectClaim,
+			UserClaim:            cfg.AuthJWTUserClaim,
+			EmailClaim:           cfg.AuthJWTEmailClaim,
+			JWKSRefreshRateLimit: cfg.AuthJWTJWKSRefreshRateLimit,
 		},
 		JWTExchanger: exchanger,
 	})
@@ -179,6 +180,7 @@ func main() {
 			"files_max_bytes", cfg.FilesMaxBytes,
 			"files_upload_timeout", cfg.FilesUploadTimeout,
 			"files_allowed_mime_count", len(cfg.FilesAllowedMIME),
+			"jwt_jwks_refresh_rate_limit", cfg.AuthJWTJWKSRefreshRateLimit,
 		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ go 1.22
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	golang.org/x/time v0.9.0
 )
 
-require (
-	github.com/MicahParks/jwkset v0.11.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
-)
+require github.com/MicahParks/jwkset v0.11.0 // indirect

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/time/rate"
 )
 
 // ErrInvalidToken signals that the inbound bearer token failed validation
@@ -25,7 +26,8 @@ var ErrJWKSUnavailable = errors.New("auth: JWKS endpoint unavailable and cache i
 
 // JWTConfig is the parsed configuration for jwt mode. All fields are
 // required except SubjectClaim/UserClaim/EmailClaim, which default to
-// "sub" / "preferred_username" / "email".
+// "sub" / "preferred_username" / "email", and JWKSRefreshRateLimit,
+// which is optional and inherits the keyfunc default when zero.
 type JWTConfig struct {
 	JWKSURL      string
 	Issuer       string
@@ -33,6 +35,19 @@ type JWTConfig struct {
 	SubjectClaim string
 	UserClaim    string
 	EmailClaim   string
+
+	// JWKSRefreshRateLimit caps how often the JWKS client will refresh
+	// the remote key set in response to a token bearing a `kid` it has
+	// not seen. When > 0 the underlying keyfunc client uses
+	// rate.NewLimiter(rate.Every(d), 1); when 0 the keyfunc default of
+	// 1 refresh per 5 minutes applies (i.e. zero means "use library
+	// default", which is conservative enough for most deployments).
+	//
+	// Tune this when a noisy-neighbour burst with forged or unknown
+	// `kid` values could otherwise hammer the JWKS endpoint. Lower
+	// values increase JWKS load; higher values delay legitimate
+	// post-rotation traffic by up to the configured interval.
+	JWKSRefreshRateLimit time.Duration
 }
 
 // JWTAuth validates an inbound bearer token against a JWKS endpoint and
@@ -83,7 +98,21 @@ func NewJWTAuth(cfg JWTConfig, exchanger *TokenExchanger) (*JWTAuth, error) {
 		cfg.EmailClaim = "email"
 	}
 
-	k, err := keyfunc.NewDefaultCtx(context.Background(), []string{cfg.JWKSURL})
+	override := keyfunc.Override{}
+	if cfg.JWKSRefreshRateLimit > 0 {
+		// One refresh per cfg.JWKSRefreshRateLimit, burst 1. Mirrors
+		// the shape of keyfunc's own default (rate.Every(5*time.Minute)),
+		// which makes it easy to reason about: a single forged-kid
+		// burst can fire at most one JWKS refresh per window.
+		override.RefreshUnknownKID = rate.NewLimiter(
+			rate.Every(cfg.JWKSRefreshRateLimit), 1,
+		)
+	}
+	k, err := keyfunc.NewDefaultOverrideCtx(
+		context.Background(),
+		[]string{cfg.JWKSURL},
+		override,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("auth: failed to initialise JWKS client: %w", err)
 	}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -465,3 +465,73 @@ func TestJWKSFixture_RoundTrip(t *testing.T) {
 	// Silence unused-import warnings for fmt when test fails are commented out.
 	_ = fmt.Sprintf
 }
+
+func TestJWTAuth_AcceptsJWKSRefreshRateLimit(t *testing.T) {
+	// Smoke test: NewJWTAuth must accept a JWKSRefreshRateLimit field
+	// without erroring. The keyfunc/jwkset internals enforce the
+	// limiter; we only assert that our wiring builds the auth object
+	// successfully and validates a normal token.
+	f := newJWKSFixture(t)
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:              f.server.URL,
+			Issuer:               testIssuer,
+			Audience:             testAudience,
+			JWKSRefreshRateLimit: 50 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New(jwt) with refresh-rate-limit: %v", err)
+	}
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	if _, err := a.Authenticate(reqWithBearer(tok)); err != nil {
+		t.Fatalf("Authenticate (rate-limit configured): %v", err)
+	}
+}
+
+func TestJWTAuth_UnknownKidRefreshIsRateLimited(t *testing.T) {
+	// keyfunc/jwkset implements the limiter via rate.Limiter.Wait,
+	// which blocks the unknown-kid lookup until the limiter allows
+	// the next refresh — it serialises rather than skips. So the
+	// observable signal that the limiter is wired through is
+	// elapsed wall time across a burst of unknown-kid tokens.
+	//
+	// With a 200ms rate-every and three forged-kid requests, the
+	// first goes through immediately and the next two each wait
+	// ~200ms — total ~400ms elapsed. Without the limiter (or with
+	// it broken), all three would resolve in milliseconds.
+	f := newJWKSFixture(t)
+	a, err := auth.New(auth.ModeJWT, auth.Options{
+		JWT: auth.JWTConfig{
+			JWKSURL:              f.server.URL,
+			Issuer:               testIssuer,
+			Audience:             testAudience,
+			JWKSRefreshRateLimit: 200 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New(jwt): %v", err)
+	}
+
+	// Warm the cache with one valid request so the startup fetch
+	// isn't part of the elapsed-time measurement.
+	tok := f.signToken(t, defaultClaims(testIssuer, testAudience), "")
+	if _, err := a.Authenticate(reqWithBearer(tok)); err != nil {
+		t.Fatalf("warm-up Authenticate: %v", err)
+	}
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		c := defaultClaims(testIssuer, testAudience)
+		forged := f.signToken(t, c, fmt.Sprintf("forged-kid-%d", i))
+		_, _ = a.Authenticate(reqWithBearer(forged))
+	}
+	elapsed := time.Since(start)
+
+	// First request consumes the burst-1 token immediately. The
+	// remaining two wait ~200ms each — at least 300ms total is a
+	// safe lower bound that still tolerates timer jitter.
+	if elapsed < 300*time.Millisecond {
+		t.Errorf("limiter not engaged: elapsed=%v across 3 forged-kid requests (want >= 300ms)", elapsed)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,16 @@ type Config struct {
 	AuthJWTUserClaim    string
 	AuthJWTEmailClaim   string
 
+	// AuthJWTJWKSRefreshRateLimit caps how often the JWKS client will
+	// refresh the key set in response to an unknown `kid`. Zero (the
+	// default) keeps keyfunc's library default of one refresh per 5
+	// minutes — already conservative enough that a forged-kid burst
+	// can't hammer Keycloak. Tune lower than 5m only if you've measured
+	// a real post-rotation latency problem; tune higher to harden
+	// against noisier neighbours. Parsed as a Go duration from
+	// GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT.
+	AuthJWTJWKSRefreshRateLimit time.Duration
+
 	// Token exchange (RFC 8693): consulted only when AuthMode == "jwt".
 	// When all four required fields (URL, ClientID, ClientSecret, Audience)
 	// are non-empty, the gateway swaps the inbound user JWT for a
@@ -188,6 +198,7 @@ func Load() (*Config, error) {
 		AuthJWTExchangeClientSecret: os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_CLIENT_SECRET"),
 		AuthJWTExchangeAudience:     os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_AUDIENCE"),
 		AuthJWTExchangeScope:        os.Getenv("GATEWAY_AUTH_JWT_TOKEN_EXCHANGE_SCOPE"),
+		AuthJWTJWKSRefreshRateLimit: 0, // resolved below; 0 ⇒ keyfunc default
 
 		PlatformURL: strings.TrimRight(os.Getenv("GATEWAY_PLATFORM_URL"), "/"),
 		// Per-prefix toggles default to true so that setting PLATFORM_URL
@@ -226,9 +237,32 @@ func Load() (*Config, error) {
 		if err := validateExchangeConfig(cfg); err != nil {
 			return nil, err
 		}
+		d, err := envDurationDefaultAllowZero("GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT", 0)
+		if err != nil {
+			return nil, err
+		}
+		cfg.AuthJWTJWKSRefreshRateLimit = d
 	}
 
 	return cfg, nil
+}
+
+// envDurationDefaultAllowZero parses a Go duration env var. Empty / unset
+// returns fallback. Negative values are rejected, zero is allowed (used by
+// JWKS refresh rate limit, where zero means "use keyfunc default").
+func envDurationDefaultAllowZero(key string, fallback time.Duration) (time.Duration, error) {
+	raw, ok := os.LookupEnv(key)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return fallback, nil
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid duration %q: %w", key, raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("%s: must be >= 0, got %q", key, raw)
+	}
+	return d, nil
 }
 
 // validateExchangeConfig fails closed on partially-configured token

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fips-agents/gateway-template/internal/config"
 )
@@ -180,6 +181,66 @@ func TestLoad_PlatformToggle_NoOpWhenURLUnset(t *testing.T) {
 	// they're cheap config knobs, not failure modes.
 	if got := cfg.SessionsTargetURL(); got != "http://agent:8080" {
 		t.Errorf("SessionsTargetURL = %q, want backend (URL unset)", got)
+	}
+}
+
+func TestLoad_JWKSRefreshRateLimit_DefaultZero(t *testing.T) {
+	cfg, err := loadWithEnv(t, jwtBaseEnv())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AuthJWTJWKSRefreshRateLimit != 0 {
+		t.Errorf("AuthJWTJWKSRefreshRateLimit = %v, want 0 (keyfunc default)", cfg.AuthJWTJWKSRefreshRateLimit)
+	}
+}
+
+func TestLoad_JWKSRefreshRateLimit_Parsed(t *testing.T) {
+	env := jwtBaseEnv()
+	env["GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT"] = "30s"
+
+	cfg, err := loadWithEnv(t, env)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := cfg.AuthJWTJWKSRefreshRateLimit, 30*time.Second; got != want {
+		t.Errorf("AuthJWTJWKSRefreshRateLimit = %v, want %v", got, want)
+	}
+}
+
+func TestLoad_JWKSRefreshRateLimit_Invalid(t *testing.T) {
+	env := jwtBaseEnv()
+	env["GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT"] = "thirty seconds"
+
+	_, err := loadWithEnv(t, env)
+	if err == nil {
+		t.Fatal("expected error on unparseable duration, got nil")
+	}
+	if !strings.Contains(err.Error(), "GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT") {
+		t.Errorf("error should reference the env var, got: %v", err)
+	}
+}
+
+func TestLoad_JWKSRefreshRateLimit_Negative(t *testing.T) {
+	env := jwtBaseEnv()
+	env["GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT"] = "-5s"
+
+	_, err := loadWithEnv(t, env)
+	if err == nil {
+		t.Fatal("expected error on negative duration, got nil")
+	}
+}
+
+func TestLoad_JWKSRefreshRateLimit_NotConsultedInAnonymousMode(t *testing.T) {
+	t.Setenv("BACKEND_URL", "http://backend:8081")
+	t.Setenv("GATEWAY_AUTH_MODE", "anonymous")
+	t.Setenv("GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT", "garbage")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load in anonymous mode should ignore the JWKS rate-limit var: %v", err)
+	}
+	if cfg.AuthJWTJWKSRefreshRateLimit != 0 {
+		t.Errorf("AuthJWTJWKSRefreshRateLimit = %v, want 0 in anonymous mode", cfg.AuthJWTJWKSRefreshRateLimit)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #28. Surfaces the JWKS unknown-`kid` refresh rate limit as a tunable knob so operators can tighten or loosen it for their deployment.

## A note on the issue's framing

The issue assumed `keyfunc.NewDefaultCtx` left `HTTPClientStorageOptions.RefreshRateLimit` "at its library default" — but that field doesn't exist. The actual lever is `Override.RefreshUnknownKID *rate.Limiter`, which keyfunc *already* defaults to `rate.NewLimiter(rate.Every(5*time.Minute), 1)` via its own constructor. So the production exposure was never as bad as feared — the gateway was already running with one refresh per 5 minutes per unknown `kid`. The wiring still has real value: it lets operators tune the window per deployment, and surfaces the knob explicitly so future operators don't have to read keyfunc internals to know it exists.

## What changed

**`internal/auth/jwt.go`**

- New `JWKSRefreshRateLimit time.Duration` field on `JWTConfig`. Doc-commented to explain the semantics: zero = keyfunc default, positive = override.
- Switched the JWKS bootstrap from `keyfunc.NewDefaultCtx` to `keyfunc.NewDefaultOverrideCtx` so we can supply `Override.RefreshUnknownKID`. Empty override when the duration is zero — behavior identical to today.
- New direct dependency on `golang.org/x/time/rate` (was already indirect via keyfunc).

**`internal/config/config.go`**

- New `AuthJWTJWKSRefreshRateLimit time.Duration` parsed from `GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT`. Validated non-negative; consulted only when `auth.mode=jwt` (consistent with the other `AuthJWT*` fields).
- Small `envDurationDefault` helper.

**`cmd/server/main.go`** — passes the new field through `auth.JWTConfig` and adds it to the startup log line.

**Helm chart**

- `values.yaml` gains `auth.jwt.jwksRefreshRateLimit: ""` with a comment.
- `configmap.yaml` emits `GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT` only when the value is set, so the default render stays clean.

**Docs** — README and CLAUDE.md tables both gain a row.

## Tests

- **`TestJWTAuth_AcceptsJWKSRefreshRateLimit`** — smoke-tests that `NewJWTAuth` accepts the new field and a normal token still validates.
- **`TestJWTAuth_UnknownKidRefreshIsRateLimited`** — measures elapsed wall time across three forged-kid requests with a 200ms window. The limiter blocks via `rate.Limiter.Wait` (serialises rather than skips), so the observable signal is elapsed time. Without the limiter all three resolve in milliseconds; with it, the run takes ~400ms. The assertion is `elapsed >= 300ms` to tolerate timer jitter.
- **Four config tests** — default zero, parsed duration (`"30s"`), invalid duration (error mentions the env var name), negative-value rejection, and ignore-in-anonymous-mode.

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] gitleaks clean
- [x] `helm template` with `auth.jwt.jwksRefreshRateLimit=30s` emits `GATEWAY_AUTH_JWT_JWKS_REFRESH_RATE_LIMIT: "30s"`; default render does not emit the env var
- [x] Default behavior unchanged when env var is unset (acceptance criterion from the issue)

## Notes for reviewer

- The behavioral test relies on wall-clock timing. 300ms is generous enough that I've never seen flakes locally, but if CI proves otherwise the floor can drop to 250ms or move to a `count fetches with `RateLimitWaitMax: 1ms` to force timeouts` model. Happy to adjust on review feedback.
- I considered also surfacing `RateLimitWaitMax` and `RefreshInterval`, but kept the surface tight per the issue scope. Easy to add later as a follow-up if anyone needs them.