### PR TITLE
observability: Propagate W3C Trace Context (traceparent) end-to-end — closes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Partial configuration (some of the four required vars set, others not) is reject
 
 All `/v1/*` endpoints forward the canonical `X-Auth-Subject` / `X-Auth-User` / `X-Auth-Email` / `X-Auth-Mode` headers (see Authentication above) so the backend can attribute requests to the resolved identity. Other request headers are dropped.
 
+W3C Trace Context (`Traceparent` / `Tracestate`) is forwarded end-to-end on every backend hop and on the outbound RFC 8693 token-exchange call, so the gateway is a transparent hop in distributed traces. The agent layer's `fipsagents.server.propagation` joins the trace on inbound, and any OTEL backend (Tempo, Honeycomb, Grafana Cloud, etc.) sees a single connected trace per request.
+
 On the response side the gateway propagates a small allowlist back to the client — currently just `X-Trace-Id`, which the agent backend sets on every chat completion response so the UI can submit feedback against a known trace.
 
 ## Deployment

--- a/internal/auth/exchange.go
+++ b/internal/auth/exchange.go
@@ -21,6 +21,15 @@ const (
 	tokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"
 )
 
+// exchangePropagationHeaders are W3C Trace Context headers forwarded from
+// the inbound user request onto the outbound POST to the authorization
+// server's token endpoint. Lets trace tooling correlate exchange-call
+// latency with the user request that triggered it.
+var exchangePropagationHeaders = []string{
+	"Traceparent",
+	"Tracestate",
+}
+
 // ErrExchangeFailed signals that a token exchange call to the authorization
 // server did not yield a usable swapped token. The middleware maps it to 503:
 // a configured exchange that does not succeed means the gateway cannot vouch
@@ -109,7 +118,14 @@ func NewTokenExchanger(cfg TokenExchangeConfig) (*TokenExchanger, error) {
 // the cached entry is still well within its TTL. Errors wrap
 // ErrExchangeFailed so callers can distinguish degraded-deployment failures
 // from caller-token failures (ErrInvalidToken).
-func (e *TokenExchanger) Exchange(ctx context.Context, subjectToken string) (string, error) {
+//
+// inboundHeaders carries W3C Trace Context (traceparent / tracestate) from
+// the inbound request; on a cache miss the values are propagated onto the
+// outbound POST to the authorization server so exchange-call latency lands
+// under the same trace as the user request. Pass nil when no inbound
+// headers are available (eg unit tests, programmatic use). Cache hits do
+// not perform an outbound call, so headers are inspected only on miss.
+func (e *TokenExchanger) Exchange(ctx context.Context, subjectToken string, inboundHeaders http.Header) (string, error) {
 	key := cacheKey(subjectToken)
 	if hit, ok := e.cache.Load(key); ok {
 		ct := hit.(cachedToken)
@@ -118,7 +134,7 @@ func (e *TokenExchanger) Exchange(ctx context.Context, subjectToken string) (str
 		}
 		e.cache.Delete(key)
 	}
-	swapped, ttl, err := e.fetch(ctx, subjectToken)
+	swapped, ttl, err := e.fetch(ctx, subjectToken, inboundHeaders)
 	if err != nil {
 		return "", err
 	}
@@ -141,7 +157,7 @@ func cacheKey(token string) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-func (e *TokenExchanger) fetch(ctx context.Context, subjectToken string) (string, time.Duration, error) {
+func (e *TokenExchanger) fetch(ctx context.Context, subjectToken string, inboundHeaders http.Header) (string, time.Duration, error) {
 	form := url.Values{}
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
@@ -160,6 +176,11 @@ func (e *TokenExchanger) fetch(ctx context.Context, subjectToken string) (string
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	for _, name := range exchangePropagationHeaders {
+		if v := inboundHeaders.Get(name); v != "" {
+			req.Header.Set(name, v)
+		}
+	}
 
 	resp, err := e.httpClient.Do(req)
 	if err != nil {

--- a/internal/auth/exchange_test.go
+++ b/internal/auth/exchange_test.go
@@ -17,9 +17,10 @@ import (
 // exchangeFixture stands in for an RFC 8693 token endpoint. It records every
 // inbound request so tests can assert on form fields and cache behaviour.
 type exchangeFixture struct {
-	server   *httptest.Server
-	calls    atomic.Int64
-	lastForm url.Values
+	server      *httptest.Server
+	calls       atomic.Int64
+	lastForm    url.Values
+	lastHeaders http.Header
 
 	// response controls the next reply.
 	status      int
@@ -39,6 +40,7 @@ func newExchangeFixture(t *testing.T) *exchangeFixture {
 		f.calls.Add(1)
 		_ = r.ParseForm()
 		f.lastForm = r.PostForm
+		f.lastHeaders = r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(f.status)
 		if f.body != "" {
@@ -100,7 +102,7 @@ func TestTokenExchanger_HappyPath_PostsRFC8693Form(t *testing.T) {
 	f := newExchangeFixture(t)
 	ex := newExchanger(t, f, func(c *auth.TokenExchangeConfig) { c.Scope = "openid email" })
 
-	got, err := ex.Exchange(context.Background(), "user-jwt-input")
+	got, err := ex.Exchange(context.Background(), "user-jwt-input", nil)
 	if err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
@@ -128,11 +130,48 @@ func TestTokenExchanger_HappyPath_PostsRFC8693Form(t *testing.T) {
 	}
 }
 
+func TestTokenExchanger_PropagatesTraceContext(t *testing.T) {
+	// W3C Trace Context headers (traceparent / tracestate) on the inbound
+	// user request must land on the outbound POST to the authorization
+	// server's token endpoint, so trace tooling can correlate exchange-call
+	// latency with the user request that triggered it.
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f)
+
+	inbound := http.Header{}
+	inbound.Set("Traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+	inbound.Set("Tracestate", "vendor=opaque-state")
+
+	if _, err := ex.Exchange(context.Background(), "user-jwt", inbound); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if got := f.lastHeaders.Get("Traceparent"); got != "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" {
+		t.Errorf("Traceparent on token-endpoint call = %q, want propagated value", got)
+	}
+	if got := f.lastHeaders.Get("Tracestate"); got != "vendor=opaque-state" {
+		t.Errorf("Tracestate on token-endpoint call = %q, want propagated value", got)
+	}
+}
+
+func TestTokenExchanger_NilHeadersOmitsPropagation(t *testing.T) {
+	// Programmatic / test callers pass nil; the exchanger must not blow up
+	// and must not invent headers the inbound request didn't carry.
+	f := newExchangeFixture(t)
+	ex := newExchanger(t, f)
+
+	if _, err := ex.Exchange(context.Background(), "user-jwt", nil); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if got := f.lastHeaders.Get("Traceparent"); got != "" {
+		t.Errorf("Traceparent should be absent when inbound headers nil, got %q", got)
+	}
+}
+
 func TestTokenExchanger_OmitsScopeWhenEmpty(t *testing.T) {
 	f := newExchangeFixture(t)
 	ex := newExchanger(t, f)
 
-	if _, err := ex.Exchange(context.Background(), "user-jwt"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "user-jwt", nil); err != nil {
 		t.Fatalf("Exchange: %v", err)
 	}
 	if _, present := f.lastForm["scope"]; present {
@@ -145,7 +184,7 @@ func TestTokenExchanger_CachesByToken(t *testing.T) {
 	ex := newExchanger(t, f)
 
 	for i := 0; i < 3; i++ {
-		got, err := ex.Exchange(context.Background(), "same-input")
+		got, err := ex.Exchange(context.Background(), "same-input", nil)
 		if err != nil {
 			t.Fatalf("Exchange (iter %d): %v", i, err)
 		}
@@ -158,7 +197,7 @@ func TestTokenExchanger_CachesByToken(t *testing.T) {
 	}
 
 	// A different subject token must trigger a fresh call.
-	if _, err := ex.Exchange(context.Background(), "different-input"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "different-input", nil); err != nil {
 		t.Fatalf("Exchange (different input): %v", err)
 	}
 	if got := f.calls.Load(); got != 2 {
@@ -175,7 +214,7 @@ func TestTokenExchanger_CacheRespectsExpiry(t *testing.T) {
 		c.Now = func() time.Time { return clock }
 	})
 
-	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 		t.Fatalf("first Exchange: %v", err)
 	}
 	if got := f.calls.Load(); got != 1 {
@@ -184,7 +223,7 @@ func TestTokenExchanger_CacheRespectsExpiry(t *testing.T) {
 
 	// Within cache TTL → no new call.
 	clock = clock.Add(20 * time.Second)
-	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 		t.Fatalf("cached Exchange: %v", err)
 	}
 	if got := f.calls.Load(); got != 1 {
@@ -194,7 +233,7 @@ func TestTokenExchanger_CacheRespectsExpiry(t *testing.T) {
 	// Past cache TTL (server expires_in 60s − 30s safety margin = 30s cap),
 	// jumping 45s forward should evict.
 	clock = clock.Add(45 * time.Second)
-	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 		t.Fatalf("post-expiry Exchange: %v", err)
 	}
 	if got := f.calls.Load(); got != 2 {
@@ -209,7 +248,7 @@ func TestTokenExchanger_DoesNotCacheNearExpiryTokens(t *testing.T) {
 	ex := newExchanger(t, f)
 
 	for i := 0; i < 3; i++ {
-		if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+		if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 			t.Fatalf("Exchange (iter %d): %v", i, err)
 		}
 	}
@@ -228,12 +267,12 @@ func TestTokenExchanger_HonoursCacheTTLCap(t *testing.T) {
 		c.CacheTTLCap = 2 * time.Minute
 	})
 
-	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 		t.Fatalf("first Exchange: %v", err)
 	}
 	// Cap should kick in well before the server's 1h.
 	clock = clock.Add(3 * time.Minute)
-	if _, err := ex.Exchange(context.Background(), "tok"); err != nil {
+	if _, err := ex.Exchange(context.Background(), "tok", nil); err != nil {
 		t.Fatalf("post-cap Exchange: %v", err)
 	}
 	if got := f.calls.Load(); got != 2 {
@@ -248,7 +287,7 @@ func TestTokenExchanger_4xxFails(t *testing.T) {
 
 	ex := newExchanger(t, f)
 
-	_, err := ex.Exchange(context.Background(), "tok")
+	_, err := ex.Exchange(context.Background(), "tok", nil)
 	if !errors.Is(err, auth.ErrExchangeFailed) {
 		t.Fatalf("want ErrExchangeFailed, got %v", err)
 	}
@@ -261,7 +300,7 @@ func TestTokenExchanger_5xxFails(t *testing.T) {
 
 	ex := newExchanger(t, f)
 
-	_, err := ex.Exchange(context.Background(), "tok")
+	_, err := ex.Exchange(context.Background(), "tok", nil)
 	if !errors.Is(err, auth.ErrExchangeFailed) {
 		t.Fatalf("want ErrExchangeFailed, got %v", err)
 	}
@@ -273,7 +312,7 @@ func TestTokenExchanger_MalformedJSONFails(t *testing.T) {
 
 	ex := newExchanger(t, f)
 
-	_, err := ex.Exchange(context.Background(), "tok")
+	_, err := ex.Exchange(context.Background(), "tok", nil)
 	if !errors.Is(err, auth.ErrExchangeFailed) {
 		t.Fatalf("want ErrExchangeFailed, got %v", err)
 	}
@@ -285,7 +324,7 @@ func TestTokenExchanger_MissingAccessTokenFails(t *testing.T) {
 
 	ex := newExchanger(t, f)
 
-	_, err := ex.Exchange(context.Background(), "tok")
+	_, err := ex.Exchange(context.Background(), "tok", nil)
 	if !errors.Is(err, auth.ErrExchangeFailed) {
 		t.Fatalf("want ErrExchangeFailed, got %v", err)
 	}
@@ -305,7 +344,7 @@ func TestTokenExchanger_TransportErrorFails(t *testing.T) {
 		t.Fatalf("NewTokenExchanger: %v", err)
 	}
 
-	_, err = ex.Exchange(context.Background(), "tok")
+	_, err = ex.Exchange(context.Background(), "tok", nil)
 	if !errors.Is(err, auth.ErrExchangeFailed) {
 		t.Fatalf("want ErrExchangeFailed, got %v", err)
 	}
@@ -318,7 +357,7 @@ func TestTokenExchanger_RequestUsesContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	_, err := ex.Exchange(ctx, "tok")
+	_, err := ex.Exchange(ctx, "tok", nil)
 	if err == nil {
 		t.Fatal("expected error from cancelled context")
 	}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -170,7 +170,7 @@ func (j *JWTAuth) Authenticate(r *http.Request) (Identity, error) {
 	}
 
 	if j.exchanger != nil {
-		swapped, err := j.exchanger.Exchange(r.Context(), tokenStr)
+		swapped, err := j.exchanger.Exchange(r.Context(), tokenStr, r.Header)
 		if err != nil {
 			// Exchange errors flow through ErrExchangeFailed (NOT
 			// ErrInvalidToken). The middleware maps non-ErrInvalidToken

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -143,6 +143,7 @@ func (h *ChatHandler) doBackendRequest(r *http.Request, body []byte) (*http.Resp
 			req.Header.Set(name, v)
 		}
 	}
+	copyPropagationHeaders(req.Header, r.Header)
 
 	return h.Client.Do(req)
 }

--- a/internal/handler/chat_test.go
+++ b/internal/handler/chat_test.go
@@ -365,6 +365,43 @@ func TestChatHandler_OmitsAuthorizationWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestChatHandler_ForwardsTraceparent(t *testing.T) {
+	// W3C Trace Context (traceparent / tracestate) flows end-to-end so the
+	// gateway is a transparent hop for distributed traces. Without this
+	// the chain breaks at the gateway and any OTEL backend shows two
+	// disconnected traces per request.
+	var captured http.Header
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"chatcmpl-x"}`))
+	}))
+	defer backend.Close()
+
+	h := &handler.ChatHandler{
+		BackendURL: backend.URL,
+		Client:     backend.Client(),
+	}
+
+	reqBody := `{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+	req.Header.Set("Tracestate", "vendor=opaque-state")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if got := captured.Get("Traceparent"); got != "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" {
+		t.Errorf("Traceparent not forwarded: got %q", got)
+	}
+	if got := captured.Get("Tracestate"); got != "vendor=opaque-state" {
+		t.Errorf("Tracestate not forwarded: got %q", got)
+	}
+}
+
 func TestChatHandler_StreamingBackendError(t *testing.T) {
 	// Backend returns 500 on a streaming request -- gateway should forward the
 	// error status rather than switching to SSE mode.

--- a/internal/handler/feedback.go
+++ b/internal/handler/feedback.go
@@ -121,6 +121,7 @@ func proxyPassthrough(w http.ResponseWriter, r *http.Request, client *http.Clien
 			req.Header.Set(name, v)
 		}
 	}
+	copyPropagationHeaders(req.Header, r.Header)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/handler/files.go
+++ b/internal/handler/files.go
@@ -141,6 +141,7 @@ func (h *FilesUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			upstream.Header.Set(name, v)
 		}
 	}
+	copyPropagationHeaders(upstream.Header, r.Header)
 
 	resp, err := h.Client.Do(upstream)
 	if err != nil {

--- a/internal/handler/propagation.go
+++ b/internal/handler/propagation.go
@@ -1,0 +1,27 @@
+package handler
+
+import "net/http"
+
+// propagationHeaders are W3C Trace Context headers forwarded end-to-end so
+// the gateway becomes a transparent hop in distributed traces. The agent
+// layer's `fipsagents.server.propagation` extracts traceparent on inbound
+// and joins the trace; without forwarding here, the chain breaks at the
+// gateway and any OTEL backend shows two disconnected traces per request.
+//
+// Kept separate from forwardedAuthHeaders / authHeaders so the auth and
+// observability concerns stay independently auditable.
+var propagationHeaders = []string{
+	"Traceparent",
+	"Tracestate",
+}
+
+// copyPropagationHeaders copies the W3C Trace Context headers from src to
+// dst. Header lookups are case-insensitive (http.Header.Get canonicalizes),
+// so this works regardless of how the inbound client cased them.
+func copyPropagationHeaders(dst http.Header, src http.Header) {
+	for _, name := range propagationHeaders {
+		if v := src.Get(name); v != "" {
+			dst.Set(name, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#29](https://github.com/fips-agents/gateway-template/issues/29). The gateway becomes a transparent hop in distributed traces: `Traceparent` / `Tracestate` headers from inbound user requests are now forwarded onto every outbound hop — backend chat completions, the platform-routed proxy, the multipart files upload, and the RFC 8693 token-exchange POST.

Without this the chain broke at the gateway. The agent's `fipsagents.server.propagation` was already extracting the header on inbound, but had nothing to read; OTEL backends showed two disconnected traces per request.

## What changed

- New `internal/handler/propagation.go` with a small `propagationHeaders` list (`Traceparent`, `Tracestate`) and a `copyPropagationHeaders` helper. Kept separate from `forwardedAuthHeaders` / `authHeaders` so the auth and observability concerns stay independently auditable.
- `ChatHandler.doBackendRequest`, `feedback.proxyPassthrough`, and `FilesUploadHandler` upstream request all call `copyPropagationHeaders` after the auth-header projection.
- `TokenExchanger.Exchange` gains an `inboundHeaders http.Header` parameter (nil-safe — programmatic / test callers pass `nil`). On a cache miss the trace headers are copied onto the outbound POST so exchange-call latency lands under the same trace as the user request. Cache hits don't perform a network call, so propagation is skipped harmlessly.
- `ForwardingHandler` already cloned all inbound headers via `pr.In.Header.Clone()`; the platform proxy path was correct already.
- README mentions the propagation behaviour alongside the existing Authentication section.

## Tests

- `TestChatHandler_ForwardsTraceparent` — `Traceparent` and `Tracestate` survive to the backend on a sync completion.
- `TestTokenExchanger_PropagatesTraceContext` — both headers land on the authorization-server token endpoint when supplied.
- `TestTokenExchanger_NilHeadersOmitsPropagation` — `nil` callers don't get phantom headers.

`go test ./... && go vet ./...` clean.

## Notes for reviewer

- The `Exchange(ctx, subjectToken)` → `Exchange(ctx, subjectToken, inboundHeaders)` signature change is a breaking change for any external caller of the public method, but the only callers are inside this repo (`internal/auth/jwt.go` and the test suite) — no published API contract is affected.
- Header pass-through is sufficient; the issue called out that a full OTEL SDK in the gateway is a separate decision (and not needed here).

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] README mentions trace context propagation
- [ ] Cluster smoke against agent-template (verify the agent layer joins the trace correctly — falls out of post-merge re-deploy)