### PR TITLE
build: Decouple PROJECT from release/image names — closes #35

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-PROJECT     ?= gateway-template
-IMAGE_NAME  ?= gateway-template
-IMAGE_TAG   ?= latest
-PORT        ?= 8080
+PROJECT       ?= gateway-template
+RELEASE_NAME  ?= gateway-template
+IMAGE_NAME    ?= gateway-template
+IMAGE_TAG     ?= latest
+PORT          ?= 8080
 
 .PHONY: build run test lint image-build build-openshift deploy clean help
 
@@ -20,18 +21,18 @@ lint:           ## Run go vet
 image-build:    ## Build container image
 	podman build --platform linux/amd64 -t $(IMAGE_NAME):$(IMAGE_TAG) -f Containerfile . --no-cache
 
-build-openshift: ## Build on OpenShift via BuildConfig (make build-openshift PROJECT=<ns>)
-	@if ! oc get bc $(PROJECT) -n $(PROJECT) &>/dev/null; then \
-		echo "Creating BuildConfig and ImageStream in $(PROJECT)..."; \
-		sed 's/PLACEHOLDER/$(PROJECT)/g' build/buildconfig.yaml | oc apply -n $(PROJECT) -f -; \
+build-openshift: ## Build on OpenShift via BuildConfig (PROJECT=<ns>, IMAGE_NAME=<bc/is>)
+	@if ! oc get bc $(IMAGE_NAME) -n $(PROJECT) &>/dev/null; then \
+		echo "Creating BuildConfig and ImageStream $(IMAGE_NAME) in $(PROJECT)..."; \
+		sed 's/PLACEHOLDER/$(IMAGE_NAME)/g' build/buildconfig.yaml | oc apply -n $(PROJECT) -f -; \
 	fi
-	oc start-build $(PROJECT) --from-dir=. -n $(PROJECT) --follow
+	oc start-build $(IMAGE_NAME) --from-dir=. -n $(PROJECT) --follow
 
-deploy:         ## Deploy to OpenShift via Helm (make deploy PROJECT=<ns>)
-	helm upgrade --install $(PROJECT) chart/ \
+deploy:         ## Deploy to OpenShift via Helm (PROJECT=<ns>, RELEASE_NAME=<release>, IMAGE_NAME=<is>)
+	helm upgrade --install $(RELEASE_NAME) chart/ \
 		-n $(PROJECT) \
-		--set image.repository=image-registry.openshift-image-registry.svc:5000/$(PROJECT)/$(PROJECT) \
-		--set image.tag=latest \
+		--set image.repository=image-registry.openshift-image-registry.svc:5000/$(PROJECT)/$(IMAGE_NAME) \
+		--set image.tag=$(IMAGE_TAG) \
 		--wait
 
 clean:          ## Remove build artifacts


### PR DESCRIPTION
## Summary

- `PROJECT` now means namespace only.
- New `RELEASE_NAME` (Helm release) and reuse of existing `IMAGE_NAME` (BC/IS) decouple the gateway's identity from where it deploys.
- `deploy` now propagates `IMAGE_TAG` into Helm instead of hardcoding `latest`.

Defaults all stay `gateway-template`, so the existing single-namespace flow is unchanged. Module 5's `make build-openshift PROJECT=calculus-agent IMAGE_NAME=calculus-gateway` and `make deploy PROJECT=calculus-agent RELEASE_NAME=calculus-gateway IMAGE_NAME=calculus-gateway` no longer collide with the agent's BC/IS/release/Deployment in the shared namespace.

Closes #35.

## Test plan

- [x] `make help` renders updated descriptions
- [x] `make -n build-openshift PROJECT=calculus-agent IMAGE_NAME=calculus-gateway` targets the gateway's BC, not the agent's
- [x] `make -n deploy PROJECT=calculus-agent RELEASE_NAME=calculus-gateway IMAGE_NAME=calculus-gateway` produces a separate Helm release and pushes to a separate IS
- [ ] End-to-end re-run of fips-agents/examples Module 5 against this branch