### PR TITLE
chart: Add checksum/config pod annotation — closes #37

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gateway-template
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.6.1
+appVersion: "0.6.1"
 description: Go HTTP gateway for AI agents

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
       {{- include "gateway-template.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll pods on ConfigMap changes so `helm upgrade --reuse-values --set config.X=Y` takes effect.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "gateway-template.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## Summary

Adds the standard `checksum/config` pod-template annotation to `chart/templates/deployment.yaml` so that ConfigMap changes trigger a pod rollout on `helm upgrade`.

## Why

Without this annotation, `helm upgrade --reuse-values --set config.X=Y` updates the ConfigMap correctly but the running pod keeps its stale env vars — the deployment hash doesn't change so Kubernetes has nothing to roll. Caught during e2e testing of fips-agents/examples Module 5: gateway pointed at the chart-default `BACKEND_URL` and returned 502 with no obvious cause.

Mirrors the agent-template pattern. Chart patch-bumped 0.6.0 → 0.6.1.

## Verification

- `helm template` renders the annotation
- Hash changes when `config.BACKEND_URL` changes (`6750a39…` → `67823ca…`), confirming pod rolls
- `helm lint` clean

Closes #37