### PR TITLE
Add .fips-template.yaml to opt into fips-agents patch flow

### DIFF
--- a/.fips-template.yaml
+++ b/.fips-template.yaml
@@ -1,0 +1,66 @@
+# fips-agents-cli template manifest.
+#
+# This file declares which paths in the gateway template are managed
+# by the template (and so should be offered as patches by `fips-agents
+# patch`) and which belong to the user. The CLI reads this file from
+# the template root after cloning, before computing drift in
+# `fips-agents patch check`.
+#
+# Without this manifest, `fips-agents patch` does not work for gateway
+# projects — `get_categories_for_type` in the CLI raises ValueError for
+# gateway / ui / sandbox project types. The presence of this file is
+# what opts the gateway template into the patch flow. See:
+#   https://github.com/fips-agents/fips-agents-cli/issues/45
+
+schema_version: 1
+
+patch:
+  categories:
+
+    chart:
+      description: Helm chart templates
+      patterns:
+        - chart/templates/**/*
+        - chart/Chart.yaml
+      ask_before_patch: true
+
+    docs:
+      description: Documentation files
+      patterns:
+        - CLAUDE.md
+        - llms.txt
+        - docs/**/*
+      ask_before_patch: false
+
+    build:
+      description: Build and deployment files
+      patterns:
+        - Makefile
+        - Containerfile
+        - .containerignore
+        - .gitignore
+      ask_before_patch: true
+
+  never_patch:
+    # User's Go entry point and HTTP wiring
+    - cmd/**
+    # User's Go internals (auth, handlers, middleware, proxy, config)
+    - internal/**
+    # User's Go module dependencies
+    - go.mod
+    - go.sum
+    # User's deploy values
+    - chart/values.yaml
+    # User-authored planning notes and helper scripts
+    - planning/**
+    - scripts/**
+    # Build artifacts (should be gitignored anyway, but defense in depth)
+    - bin/**
+    - build/**
+    # Tests are user code
+    - "**/*_test.go"
+    # Environment files
+    - .env*
+    # User's README, license
+    - README.md
+    - LICENSE


### PR DESCRIPTION
Companion PR to fips-agents/fips-agents-cli#48 (the manifest loader). After both merge, \`fips-agents patch\` will work for projects scaffolded from this template — it doesn't today, because the CLI's hardcoded fallback raises \`ValueError\` for the \`gateway\` project type.

## What

Adds \`.fips-template.yaml\` at the repo root with \`schema_version: 1\`. Three categories declared:

- \`chart\` — \`chart/templates/**/*\`, \`chart/Chart.yaml\` (ask before patch).
- \`docs\` — \`CLAUDE.md\`, \`llms.txt\`, \`docs/**/*\`.
- \`build\` — \`Makefile\`, \`Containerfile\`, \`.containerignore\`, \`.gitignore\` (ask before patch).

Plus a 13-entry \`never_patch\` list:

- \`cmd/**\`, \`internal/**\` — user's Go code.
- \`go.mod\`, \`go.sum\` — user's deps.
- \`chart/values.yaml\` — user's deploy config.
- \`planning/**\`, \`scripts/**\` — user-authored.
- \`bin/**\`, \`build/**\` — build artifacts.
- \`**/*_test.go\` — tests are user code.
- \`.env*\`, \`README.md\`, \`LICENSE\`.

## What this enables

After the CLI loader (fips-agents/fips-agents-cli#48) ships:

\`\`\`bash
$ fips-agents patch check
                    Available Updates
┏━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Category ┃ Files Changed ┃ Description                ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ build    │ 1             │ Build and deployment files │
└──────────┴───────────────┴────────────────────────────┘
\`\`\`

Today this same command crashes with \`ValueError: Patching is not supported for project type 'gateway'\`.

## Compatibility

Older CLI installs that don't know about \`.fips-template.yaml\` continue to refuse \`patch\` for gateway projects exactly as before. The file is invisible to them, so this PR is non-breaking.

## Test plan

- [x] Manifest parses cleanly through \`fips_agents_cli.tools.patching._load_template_manifest\` and \`_categories_from_manifest\` (validated locally against PR #48's loader).
- [x] \`_resolve_categories\` correctly returns the manifest's categories instead of raising.
- [x] No secrets detected by gitleaks.
- [ ] After CLI #48 merges and ships in a release, scaffold a gateway project and run \`patch check\` against this template — should report drift only in chart/docs/build categories, never in cmd/ or internal/.